### PR TITLE
Loggers

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Generate coverage report
       run: |
         python -m pip install pytest-cov
-        python -m  pytest --cov=./ --cov-report=xml:coverage.xml
+        python -m  pytest --disable-warnings --cov=./ --cov-report=xml:coverage.xml
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1
       with:

--- a/.github/workflows/pr_rev_tests.yml
+++ b/.github/workflows/pr_rev_tests.yml
@@ -37,4 +37,4 @@ jobs:
       working-directory: ./reV
       run: |
         python -m pip install pytest
-        python -m pytest -v
+        python -m pytest -v --disable-warnings

--- a/.github/workflows/pr_revx_tests.yml
+++ b/.github/workflows/pr_revx_tests.yml
@@ -42,4 +42,4 @@ jobs:
       shell: bash -l {0}
       run: |
         conda install pytest
-        pytest -v
+        pytest -v --disable-warnings

--- a/.github/workflows/pull_request_tests.yml
+++ b/.github/workflows/pull_request_tests.yml
@@ -30,7 +30,7 @@ jobs:
         python -m pip install .
     - name: Run pytest and Generate coverage report
       run: |
-        python -m pytest -v --cov=./ --cov-report=xml:coverage.xml
+        python -m pytest -v --disable-warnings --cov=./ --cov-report=xml:coverage.xml
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1
       with:

--- a/rex/__init__.py
+++ b/rex/__init__.py
@@ -17,10 +17,14 @@ from rex.rechunk_h5 import RechunkH5, to_records_array
 from rex.renewable_resource import (NSRDB, SolarResource, WindResource,
                                     WaveResource)
 from rex.resource import Resource
-from rex.resource_extraction import (ResourceX, MultiYearResourceX,
-                                     NSRDBX, MultiFileNSRDBX, MultiYearNSRDBX,
-                                     WindX, MultiFileWindX, MultiYearWindX,
-                                     WaveX, MultiYearWaveX, TemporalStats)
+from rex.resource_extraction import (ResourceX, MultiTimeResourceX,
+                                     MultiYearResourceX,
+                                     NSRDBX, MultiFileNSRDBX, MultiTimeNSRDBX,
+                                     MultiYearNSRDBX,
+                                     WindX, MultiFileWindX, MultiTimeWindX,
+                                     MultiYearWindX,
+                                     WaveX, MultiTimeWaveX, MultiYearWaveX,
+                                     TemporalStats)
 from rex.utilities import init_logger, init_mult, SpawnProcessPool, SLURM, PBS
 
 from rex.version import __version__

--- a/rex/rechunk_h5/combine_h5_cli.py
+++ b/rex/rechunk_h5/combine_h5_cli.py
@@ -1,13 +1,16 @@
 # -*- coding: utf-8 -*-
 """
-Rechunk h5 command line interface
+Combined h5 command line interface
 """
 import click
+import logging
 import os
 
 from rex.rechunk_h5.combine_h5 import CombineH5
 from rex.utilities.cli_dtypes import INT
 from rex.utilities.loggers import init_logger
+
+logger = logging.getLogger(__name__)
 
 
 @click.command()
@@ -25,7 +28,7 @@ from rex.utilities.loggers import init_logger
               help="Size of each chunk to be processed")
 @click.option('--log_file', '-log', default=None, type=click.Path(),
               show_default=True,
-              help='Path to .log file')
+              help='Path to .log file, if None only log to stdout')
 @click.option('--verbose', '-v', is_flag=True,
               help='If used upgrade logging to DEBUG')
 def main(combined_h5, source_h5, axis, overwrite, process_size, log_file,
@@ -43,8 +46,7 @@ def main(combined_h5, source_h5, axis, overwrite, process_size, log_file,
         if not os.path.exists(log_dir):
             os.makedirs(log_dir)
 
-    init_logger('rex.rechunk_h5.combine_h5', log_file=log_file,
-                log_level=log_level)
+    init_logger('rex', log_file=log_file, log_level=log_level)
 
     dst_dir = os.path.dirname(combined_h5)
     if not os.path.exists(dst_dir):
@@ -56,6 +58,7 @@ def main(combined_h5, source_h5, axis, overwrite, process_size, log_file,
 
 if __name__ == '__main__':
     try:
-        main()
+        main(obj={})
     except Exception:
+        logger.exception('Error running Combined H5')
         raise

--- a/rex/rechunk_h5/rechunk_cli.py
+++ b/rex/rechunk_h5/rechunk_cli.py
@@ -3,11 +3,14 @@
 Rechunk h5 command line interface
 """
 import click
+import logging
 import os
 
 from rex.rechunk_h5.rechunk_h5 import RechunkH5
 from rex.utilities.cli_dtypes import INT, STR
 from rex.utilities.loggers import init_logger
+
+logger = logging.getLogger(__name__)
 
 
 @click.command()
@@ -39,7 +42,7 @@ from rex.utilities.loggers import init_logger
               help='New time resolution')
 @click.option('--log_file', '-log', default=None, type=click.Path(),
               show_default=True,
-              help='Path to .log file')
+              help='Path to .log file, if None only log to stdout')
 @click.option('--verbose', '-v', is_flag=True,
               help='If used upgrade logging to DEBUG')
 def main(src_h5, dst_h5, var_attrs_path, hub_height, version, overwrite,
@@ -57,8 +60,7 @@ def main(src_h5, dst_h5, var_attrs_path, hub_height, version, overwrite,
         if not os.path.exists(log_dir):
             os.makedirs(log_dir)
 
-    init_logger('rex.rechunk_h5.rechunk_h5', log_file=log_file,
-                log_level=log_level)
+    init_logger('rex', log_file=log_file, log_level=log_level)
 
     dst_dir = os.path.dirname(dst_h5)
     if not os.path.exists(dst_dir):
@@ -72,6 +74,7 @@ def main(src_h5, dst_h5, var_attrs_path, hub_height, version, overwrite,
 
 if __name__ == '__main__':
     try:
-        main()
+        main(obj={})
     except Exception:
+        logger.exception('Error running Combined H5')
         raise

--- a/rex/resource_extraction/US_wave_cli.py
+++ b/rex/resource_extraction/US_wave_cli.py
@@ -20,7 +20,7 @@ from rex.resource_extraction.multi_year_resource_cli \
     import multi_year as multi_yr_means_cmd
 from rex.resource_extraction.resource_extraction import MultiYearWaveX
 from rex.utilities.cli_dtypes import STRLIST, INTLIST
-from rex.utilities.loggers import init_mult
+from rex.utilities.loggers import init_logger
 from rex import __version__
 
 logger = logging.getLogger(__name__)
@@ -40,10 +40,13 @@ logger = logging.getLogger(__name__)
               help="Boolean flag to use access virtual buoy data")
 @click.option('--eagle', '-hpc', is_flag=True,
               help="Boolean flag to use access data on NRELs HPC vs. via HSDS")
+@click.option('--log_file', '-log', default=None, type=click.Path(),
+              show_default=True,
+              help='Path to .log file, if None only log to stdout')
 @click.option('-v', '--verbose', is_flag=True,
               help='Flag to turn on debug logging. Default is not verbose.')
 @click.pass_context
-def main(ctx, domain, out_dir, years, buoy, eagle, verbose):
+def main(ctx, domain, out_dir, years, buoy, eagle, log_file, verbose):
     """
     US Wave Command Line Interface
     """
@@ -65,10 +68,17 @@ def main(ctx, domain, out_dir, years, buoy, eagle, verbose):
     ctx.obj['CLS_KWARGS'] = {'years': years, 'hsds': hsds}
     ctx.obj['CLS'] = MultiYearWaveX
 
-    name = os.path.splitext(os.path.basename(path))[0]
-    init_mult(name, out_dir, verbose=verbose, node=True,
-              modules=[__name__, 'rex.resource_extraction',
-                       'rex.multi_year_resource'])
+    if verbose:
+        log_level = 'DEBUG'
+    else:
+        log_level = 'INFO'
+
+    if log_file is not None:
+        log_dir = os.path.dirname(log_file)
+        if not os.path.exists(log_dir):
+            os.makedirs(log_dir)
+
+    init_logger('rex', log_file=log_file, log_level=log_level)
 
     logger.info('Extracting US wave data for {} from {}'.format(domain, path))
     logger.info('Outputs to be stored in: {}'.format(out_dir))

--- a/rex/resource_extraction/nsrdb_cli.py
+++ b/rex/resource_extraction/nsrdb_cli.py
@@ -15,7 +15,7 @@ from rex.resource_extraction.resource_cli import multi_site as multi_site_cmd
 from rex.resource_extraction.resource_cli import region as region_cmd
 from rex.resource_extraction.resource_cli import sam_datasets as sam_cmd
 from rex.resource_extraction.resource_cli import site as site_cmd
-from rex.utilities.loggers import init_mult
+from rex.utilities.loggers import init_logger
 from rex.utilities.utilities import check_res_file
 from rex import __version__
 
@@ -28,10 +28,13 @@ logger = logging.getLogger(__name__)
               help=('Path to Resource .h5 file'))
 @click.option('--out_dir', '-o', required=True, type=click.Path(exists=True),
               help='Directory to dump output files')
+@click.option('--log_file', '-log', default=None, type=click.Path(),
+              show_default=True,
+              help='Path to .log file, if None only log to stdout')
 @click.option('-v', '--verbose', is_flag=True,
               help='Flag to turn on debug logging. Default is not verbose.')
 @click.pass_context
-def main(ctx, solar_h5, out_dir, verbose):
+def main(ctx, solar_h5, out_dir, log_file, verbose):
     """
     NSRDBX Command Line Interface
     """
@@ -56,9 +59,17 @@ def main(ctx, solar_h5, out_dir, verbose):
         else:
             ctx.obj['CLS'] = SolarX
 
-    init_mult(name, out_dir, verbose=verbose, node=True,
-              modules=[__name__, 'rex.resource_extraction',
-                       'rex.renewable_resource'])
+    if verbose:
+        log_level = 'DEBUG'
+    else:
+        log_level = 'INFO'
+
+    if log_file is not None:
+        log_dir = os.path.dirname(log_file)
+        if not os.path.exists(log_dir):
+            os.makedirs(log_dir)
+
+    init_logger('rex', log_file=log_file, log_level=log_level)
 
     logger.info('Extracting solar data from {}'.format(solar_h5))
     logger.info('Outputs to be stored in: {}'.format(out_dir))

--- a/rex/resource_extraction/resource_cli.py
+++ b/rex/resource_extraction/resource_cli.py
@@ -3,13 +3,13 @@
 ResourceX Command Line Interface
 """
 import click
-import logging
 import os
+import logging
 import pandas as pd
 
 from rex.resource_extraction.resource_extraction import (ResourceX,
                                                          MultiFileResourceX)
-from rex.utilities.loggers import init_mult
+from rex.utilities.loggers import init_logger
 from rex.utilities.utilities import check_res_file
 from rex import __version__
 
@@ -61,10 +61,13 @@ def _parse_sites(sites):
               help=('Path to Resource .h5 file'))
 @click.option('--out_dir', '-o', required=True, type=click.Path(),
               help='Directory to dump output files')
+@click.option('--log_file', '-log', default=None, type=click.Path(),
+              show_default=True,
+              help='Path to .log file, if None only log to stdout')
 @click.option('-v', '--verbose', is_flag=True,
               help='Flag to turn on debug logging. Default is not verbose.')
 @click.pass_context
-def main(ctx, resource_h5, out_dir, verbose):
+def main(ctx, resource_h5, out_dir, log_file, verbose):
     """
     ResourceX Command Line Interface
     """
@@ -85,10 +88,17 @@ def main(ctx, resource_h5, out_dir, verbose):
 
         ctx.obj['CLS'] = ResourceX
 
-    name = os.path.splitext(os.path.basename(resource_h5))[0]
-    init_mult(name, out_dir, verbose=verbose, node=True,
-              modules=[__name__, 'rex.resource_extraction',
-                       'rex.resource'])
+    if verbose:
+        log_level = 'DEBUG'
+    else:
+        log_level = 'INFO'
+
+    if log_file is not None:
+        log_dir = os.path.dirname(log_file)
+        if not os.path.exists(log_dir):
+            os.makedirs(log_dir)
+
+    init_logger('rex', log_file=log_file, log_level=log_level)
 
     logger.info('Extracting Resource data from {}'.format(resource_h5))
     logger.info('Outputs to be stored in: {}'.format(out_dir))

--- a/rex/resource_extraction/wave_cli.py
+++ b/rex/resource_extraction/wave_cli.py
@@ -14,7 +14,7 @@ from rex.resource_extraction.resource_cli import multi_site as multi_site_cmd
 from rex.resource_extraction.resource_cli import region as region_cmd
 from rex.resource_extraction.resource_cli import sam_datasets as sam_cmd
 from rex.resource_extraction.resource_cli import site as site_cmd
-from rex.utilities.loggers import init_mult
+from rex.utilities.loggers import init_logger
 from rex.utilities.utilities import check_res_file
 from rex import __version__
 
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 @click.option('-v', '--verbose', is_flag=True,
               help='Flag to turn on debug logging. Default is not verbose.')
 @click.pass_context
-def main(ctx, wave_h5, out_dir, verbose):
+def main(ctx, wave_h5, out_dir, log_file, verbose):
     """
     WaveX Command Line Interface
     """
@@ -41,15 +41,22 @@ def main(ctx, wave_h5, out_dir, verbose):
     ctx.obj['CLS'] = WaveX
 
     _, hsds = check_res_file(wave_h5)
-    name = os.path.splitext(os.path.basename(wave_h5))[0]
     if hsds:
         ctx.obj['CLS_KWARGS']['hsds'] = hsds
     else:
         assert os.path.exists(wave_h5)
 
-    init_mult(name, out_dir, verbose=verbose, node=True,
-              modules=[__name__, 'rex.resource_extraction',
-                       'rex.renewable_resource'])
+    if verbose:
+        log_level = 'DEBUG'
+    else:
+        log_level = 'INFO'
+
+    if log_file is not None:
+        log_dir = os.path.dirname(log_file)
+        if not os.path.exists(log_dir):
+            os.makedirs(log_dir)
+
+    init_logger('rex', log_file=log_file, log_level=log_level)
 
     logger.info('Extracting wave data from {}'.format(wave_h5))
     logger.info('Outputs to be stored in: {}'.format(out_dir))

--- a/rex/resource_extraction/wind_cli.py
+++ b/rex/resource_extraction/wind_cli.py
@@ -14,7 +14,7 @@ from rex.resource_extraction.resource_cli import multi_site as multi_site_cmd
 from rex.resource_extraction.resource_cli import _parse_sites
 from rex.resource_extraction.resource_cli import region as region_cmd
 from rex.resource_extraction.resource_cli import site as site_cmd
-from rex.utilities.loggers import init_mult
+from rex.utilities.loggers import init_logger
 from rex.utilities.utilities import check_res_file
 from rex import __version__
 
@@ -27,10 +27,13 @@ logger = logging.getLogger(__name__)
               help=('Path to Resource .h5 file'))
 @click.option('--out_dir', '-o', required=True, type=click.Path(exists=True),
               help='Directory to dump output files')
+@click.option('--log_file', '-log', default=None, type=click.Path(),
+              show_default=True,
+              help='Path to .log file, if None only log to stdout')
 @click.option('-v', '--verbose', is_flag=True,
               help='Flag to turn on debug logging. Default is not verbose.')
 @click.pass_context
-def main(ctx, wind_h5, out_dir, verbose):
+def main(ctx, wind_h5, out_dir, log_file, verbose):
     """
     WindX Command Line Interface
     """
@@ -51,10 +54,17 @@ def main(ctx, wind_h5, out_dir, verbose):
 
         ctx.obj['CLS'] = WindX
 
-    name = os.path.splitext(os.path.basename(wind_h5))[0]
-    init_mult(name, out_dir, verbose=verbose, node=True,
-              modules=[__name__, 'rex.resource_extraction',
-                       'rex.renewable_resource'])
+    if verbose:
+        log_level = 'DEBUG'
+    else:
+        log_level = 'INFO'
+
+    if log_file is not None:
+        log_dir = os.path.dirname(log_file)
+        if not os.path.exists(log_dir):
+            os.makedirs(log_dir)
+
+    init_logger('rex', log_file=log_file, log_level=log_level)
 
     logger.info('Extracting Wind data from {}'.format(wind_h5))
     logger.info('Outputs to be stored in: {}'.format(out_dir))

--- a/rex/utilities/exceptions.py
+++ b/rex/utilities/exceptions.py
@@ -110,3 +110,9 @@ class SAMInputWarning(Warning):
     """
     Warning for bad SAM inputs
     """
+
+
+class LoggerWarning(Warning):
+    """
+    Warning for bad logger inputs
+    """

--- a/rex/utilities/execution.py
+++ b/rex/utilities/execution.py
@@ -129,7 +129,7 @@ class SubprocessManager:
             cmd = nohup_cmd.format(cmd)
             shell = True
 
-        subprocess.run(cmd, shell=shell)
+        subprocess.run(cmd, shell=shell, check=True)
 
     @staticmethod
     def submit(cmd, background=False, background_stdout=False):
@@ -228,7 +228,7 @@ class SpawnProcessPool(cf.ProcessPoolExecutor):
             kwargs['mp_context'] = multiprocessing.get_context('spawn')
 
         if loggers is not None:
-            kwargs['initializer'] = LOGGERS.init_logger
+            kwargs['initializer'] = LOGGERS.init_loggers
             kwargs['initargs'] = (loggers, )
 
         super().__init__(*args, **kwargs)

--- a/rex/utilities/loggers.py
+++ b/rex/utilities/loggers.py
@@ -201,6 +201,8 @@ def clear_handlers(logger):
 
         logger.removeHandler(handler)
 
+    logger.handlers.clear()
+
     return logger
 
 
@@ -257,14 +259,14 @@ class LoggingAttributes:
 
         Parameters
         ----------
-        handlers : None | list
+        handlers : list
             None or list of existing file handlers
         new_handlers : list
             List of new file handlers to add to logger
 
         Returns
         -------
-        handlers : list | None
+        handlers : list
            Updated list of valid log files to add to handler
         """
         if not isinstance(new_handlers, (list, tuple)):
@@ -282,9 +284,6 @@ class LoggingAttributes:
                     warn('{} does not exist, FileHandler will be '
                          'converted to a StreamHandler'
                          .format(log_dir), LoggerWarning)
-
-        if not handlers:
-            handlers = None
 
         return handlers
 
@@ -315,6 +314,8 @@ class LoggingAttributes:
                         handlers = []
 
                     handlers = cls._check_file_handlers(handlers, value)
+                    if not handlers:
+                        handlers = None
                 else:
                     handlers = None
 
@@ -448,13 +449,14 @@ class LoggingAttributes:
         """
         Clear all log handlers
         """
-        self._loggers = {}
         for name, logger in logging.Logger.manager.loggerDict.items():
             if isinstance(logger, logging.Logger):
                 for p_name in self.logger_names:
                     if name.startswith(p_name):
                         clear_handlers(logger)
                         break
+
+        self._loggers = {}
 
 
 LOGGERS = LoggingAttributes()

--- a/rex/utilities/loggers.py
+++ b/rex/utilities/loggers.py
@@ -275,8 +275,11 @@ class LoggingAttributes:
                 if handlers is None:
                     handlers = []
 
+                # make the log_file request into a iterable list
+                if not isinstance(handlers, (list, tuple)):
+                    handlers = [handlers]
+
                 if not isinstance(value, (list, tuple)):
-                    # make the log_file request into a iterable list
                     value = [value]
 
                 for v in value:

--- a/rex/utilities/loggers.py
+++ b/rex/utilities/loggers.py
@@ -130,17 +130,18 @@ def setup_logger(logger_name, stream=True, log_level="INFO", log_file=None,
     ----------
     logger_name : str
         Name of logger
-    stream : bool
-        Init stream logger
-    log_level : str
+    stream : bool, optional
+        Add a StreamHandler along with FileHandler, by default True
+    log_level : str, optional
         Level of logging to capture, must be key in LOG_LEVEL. If multiple
         handlers/log_files are requested in a single call of this function,
-        the specified logging level will be applied to all requested handlers.
-    log_file : str | list
+        the specified logging level will be applied to all requested handlers,
+        by default "INFO"
+    log_file : str | list, optional
         Path to file to use for logging, if None use a StreamHandler
-        list of multiple handlers is permitted
-    log_format : str
-        Format for loggings, default is FORMAT
+        list of multiple handlers is permitted, by default None
+    log_format : str, optional
+        Format for loggings, by default FORMAT
 
     Returns
     -------
@@ -186,7 +187,9 @@ class LoggingAttributes:
         return msg
 
     def __setitem__(self, logger_name, attributes):
-        self.setup_logger(logger_name, **attributes)
+        log_attrs = self[logger_name]
+        log_attrs = self._update_attrs(attributes)
+        self._loggers[logger_name] = log_attrs
 
     def __getitem__(self, logger_name):
         return self._loggers.get(logger_name, {}).copy()
@@ -325,18 +328,18 @@ class LoggingAttributes:
         ----------
         logger_name : str
             Name of logger
-        stream : bool
-            Init stream logger
-        log_level : str
+        stream : bool, optional
+            Add a StreamHandler along with FileHandler, by default True
+        log_level : str, optional
             Level of logging to capture, must be key in LOG_LEVEL. If multiple
             handlers/log_files are requested in a single call of this function,
             the specified logging level will be applied to all requested
-            handlers.
-        log_file : str | list
+            handlers, by default "INFO"
+        log_file : str | list, optional
             Path to file to use for logging, if None use a StreamHandler
-            list of multiple handlers is permitted
-        log_format : str
-            Format for loggings, default is FORMAT
+            list of multiple handlers is permitted, by default None
+        log_format : str, optional
+            Format for loggings, by default FORMAT
 
         Returns
         -------
@@ -381,23 +384,29 @@ LOGGERS = LoggingAttributes()
 
 
 def init_logger(logger_name, stream=True, log_level="INFO", log_file=None,
-                log_format=FORMAT):
+                log_format=FORMAT, prune=True):
     """
-    Starts logging instance and adds logging attributes to REV_LOGGERS
+    Starts logging instance and adds logging attributes to LOGGERS
 
     Parameters
     ----------
     logger_name : str
         Name of logger to initialize
-    log_level : str
+    stream : bool, optional
+        Add a StreamHandler along with FileHandler, by default True
+    log_level : str, optional
         Level of logging to capture, must be key in LOG_LEVEL. If multiple
         handlers/log_files are requested in a single call of this function,
-        the specified logging level will be applied to all requested handlers.
-    log_file : str | list
+        the specified logging level will be applied to all requested handlers,
+        by default "INFO"
+    log_file : str | list, optional
         Path to file to use for logging, if None use a StreamHandler
-        list of multiple handlers is permitted
-    log_format : str
-        Format for loggings, default is FORMAT
+        list of multiple handlers is permitted, by default None
+    log_format : str, optional
+        Format for loggings, by default FORMAT
+    prune : bool, optional
+        Remove child logger handlers if parent logger is added, parent will
+        inherit child's handlers, by default True
 
     Returns
     -------
@@ -406,7 +415,11 @@ def init_logger(logger_name, stream=True, log_level="INFO", log_file=None,
     """
     kwargs = {"log_level": log_level, "log_file": log_file,
               "log_format": log_format, 'stream': stream}
-    logger = LOGGERS.setup_logger(logger_name, **kwargs)
+    if prune:
+        logger = LOGGERS.setup_logger(logger_name, **kwargs)
+    else:
+        LOGGERS[logger_name] = kwargs
+        logger = setup_logger(logger_name, **kwargs)
 
     return logger
 

--- a/rex/utilities/loggers.py
+++ b/rex/utilities/loggers.py
@@ -514,7 +514,7 @@ def init_mult(name, logdir, modules, verbose=False, node=False):
             # Node level info loggers only go to STDOUT/STDERR files
             logger = init_logger(module, log_level=log_level, log_file=None)
         else:
-            logger = init_logger(module, module, log_level=log_level,
+            logger = init_logger(module, log_level=log_level,
                                  log_file=log_file)
 
         loggers.append(logger)

--- a/rex/version.py
+++ b/rex/version.py
@@ -1,3 +1,3 @@
 """rex Version number"""
 
-__version__ = "0.2.36"
+__version__ = "0.2.37"

--- a/tests/test_combine_h5.py
+++ b/tests/test_combine_h5.py
@@ -11,6 +11,7 @@ import tempfile
 import traceback
 
 from rex.rechunk_h5.combine_h5_cli import main
+from rex.utilities.loggers import LOGGERS
 from rex import TESTDATADIR
 
 
@@ -91,6 +92,8 @@ def test_combine_h5(runner, axis):
         assert result.exit_code == 0, msg
 
         check_combine(src_path, combine_path, axis=axis)
+
+    LOGGERS.clear()
 
 
 def execute_pytest(capture='all', flags='-rapP'):

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+"""
+pytests for logging methodology
+"""
+import os
+import pytest
+import tempfile
+
+from rex.utilities.exceptions import LoggerWarning
+from rex.utilities.loggers import (init_logger, LOGGERS, add_handlers,
+                                   get_handler)
+
+
+def test_loggers():
+    """
+    Test logger initilization and handling
+    """
+    with tempfile.TemporaryDirectory() as td:
+        logger = init_logger('rex.test')
+        assert len(logger.handlers) == 1
+        assert len(LOGGERS.loggers) == 1
+
+        # Add file handler
+        log_file = os.path.join(td, 'test.log')
+        handler = get_handler(log_file=log_file)
+        logger = add_handlers(logger, [handler])
+        assert len(logger.handlers) == 2
+
+        # update stream handler
+        handler = get_handler(log_level='debug')
+        logger = add_handlers(logger, [handler])
+        assert len(logger.handlers) == 2
+
+        # add second file_handler
+        log_file = os.path.join(td, 'log.log')
+        handler = get_handler(log_level='debug', log_file=log_file)
+        logger = add_handlers(logger, [handler])
+        assert len(logger.handlers) == 3
+
+        # re-initilize 'rex.test'
+        logger.handlers.clear()
+        log_file = os.path.join(td, 'test.log')
+        logger = init_logger('rex.test', log_file=log_file, log_level='DEBUG')
+        assert len(logger.handlers) == 2
+        assert len(LOGGERS.loggers) == 1
+
+        # Add parent logger removing 'rex.test' but inheriting handlers and
+        # level
+        logger = init_logger('rex')
+        assert len(logger.handlers) == 2
+        assert logger.level == 10
+        assert len(LOGGERS.loggers) == 1
+
+
+def test_bad_log_dir():
+    """
+    test bad log dir warning and converstion to stream logger
+    """
+    with pytest.warns(LoggerWarning):
+        log_file = '/abc/log.log'
+        logger = init_logger(__name__, log_file=log_file)
+        assert len(logger.handlers) == 1
+        assert logger.handlers[0].name == 'stream'
+
+
+def execute_pytest(capture='all', flags='-rapP'):
+    """Execute module as pytest with detailed summary report.
+
+    Parameters
+    ----------
+    capture : str
+        Log or stdout/stderr capture option. ex: log (only logger),
+        all (includes stdout/stderr)
+    flags : str
+        Which tests to show logs and results for.
+    """
+
+    fname = os.path.basename(__file__)
+    pytest.main(['-q', '--show-capture={}'.format(capture), fname, flags])
+
+
+if __name__ == '__main__':
+    execute_pytest()

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -38,16 +38,14 @@ def test_loggers():
         assert len(logger.handlers) == 3
 
         # re-initilize 'rex.test'
-        for h in logger.handlers:
-            h.close()
+        LOGGERS.clear()
 
         logger.handlers.clear()
         log_file = os.path.join(td, 'test.log')
         logger = init_logger('rex.test', log_file=log_file, log_level='DEBUG')
         assert len(logger.handlers) == 2
         assert len(LOGGERS.loggers) == 1
-        for h in logger.handlers:
-            h.close()
+        LOGGERS.clear()
 
         # Add parent logger removing 'rex.test' but inheriting handlers and
         # level
@@ -55,6 +53,8 @@ def test_loggers():
         assert len(logger.handlers) == 2
         assert logger.level == 10
         assert len(LOGGERS.loggers) == 1
+
+    LOGGERS.clear()
 
 
 def test_bad_log_dir():
@@ -67,8 +67,7 @@ def test_bad_log_dir():
         assert len(logger.handlers) == 1
         assert logger.handlers[0].name == 'stream'
 
-
-LOGGERS.clear()
+    LOGGERS.clear()
 
 
 def execute_pytest(capture='all', flags='-rapP'):

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -45,6 +45,8 @@ def test_loggers():
         logger = init_logger('rex.test', log_file=log_file, log_level='DEBUG')
         assert len(logger.handlers) == 2
         assert len(LOGGERS.loggers) == 1
+        for h in logger.handlers:
+            h.close()
 
         # Add parent logger removing 'rex.test' but inheriting handlers and
         # level

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -38,11 +38,16 @@ def test_loggers():
         assert len(logger.handlers) == 3
 
         # re-initilize 'rex.test'
+        for h in logger.handlers:
+            h.close()
+
         logger.handlers.clear()
         log_file = os.path.join(td, 'test.log')
         logger = init_logger('rex.test', log_file=log_file, log_level='DEBUG')
         assert len(logger.handlers) == 2
         assert len(LOGGERS.loggers) == 1
+        for h in logger.handlers:
+            h.close()
 
         # Add parent logger removing 'rex.test' but inheriting handlers and
         # level

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -46,6 +46,7 @@ def test_loggers():
         assert len(logger.handlers) == 2
         assert len(LOGGERS.loggers) == 1
         for h in logger.handlers:
+            h.flush()
             h.close()
 
         # Add parent logger removing 'rex.test' but inheriting handlers and

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -68,6 +68,9 @@ def test_bad_log_dir():
         assert logger.handlers[0].name == 'stream'
 
 
+LOGGERS.clear()
+
+
 def execute_pytest(capture='all', flags='-rapP'):
     """Execute module as pytest with detailed summary report.
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -56,7 +56,7 @@ def test_loggers():
         assert logger.level == 10
         assert len(LOGGERS.loggers) == 1
 
-    LOGGERS.clear()
+        LOGGERS.clear()
 
 
 def test_bad_log_dir():
@@ -68,6 +68,8 @@ def test_bad_log_dir():
         logger = init_logger(__name__, log_file=log_file)
         assert len(logger.handlers) == 1
         assert logger.handlers[0].name == 'stream'
+        print(LOGGERS.loggers)
+        assert LOGGERS.loggers[__name__]['log_file'] is None
 
     LOGGERS.clear()
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -45,7 +45,6 @@ def test_loggers():
         logger = init_logger('rex.test', log_file=log_file, log_level='DEBUG')
         assert len(logger.handlers) == 2
         assert len(LOGGERS.loggers) == 1
-        LOGGERS.clear()
 
         # Add parent logger removing 'rex.test' but inheriting handlers and
         # level

--- a/tests/test_rechunk_h5.py
+++ b/tests/test_rechunk_h5.py
@@ -159,8 +159,7 @@ def test_downscale(runner):
 
         check_rechunk(truth_path, rechunk_path)
 
-
-LOGGERS.clear()
+    LOGGERS.clear()
 
 
 def test_hub_height(runner):

--- a/tests/test_rechunk_h5.py
+++ b/tests/test_rechunk_h5.py
@@ -14,7 +14,10 @@ from rex.resource import Resource
 from rex.rechunk_h5.rechunk_h5 import (get_dataset_attributes,
                                        to_records_array)
 from rex.rechunk_h5.rechunk_cli import main
+from rex.utilities.loggers import LOGGERS
 from rex import TESTDATADIR
+
+LOGGERS.clear()
 
 
 @pytest.fixture(scope="module")
@@ -130,6 +133,8 @@ def test_rechunk_h5(runner, drop):
 
         check_rechunk(src_path, rechunk_path, missing=drop)
 
+    LOGGERS.clear()
+
 
 def test_downscale(runner):
     """
@@ -153,6 +158,9 @@ def test_downscale(runner):
         assert result.exit_code == 0, msg
 
         check_rechunk(truth_path, rechunk_path)
+
+
+LOGGERS.clear()
 
 
 def test_hub_height(runner):

--- a/tests/test_resource_extraction.py
+++ b/tests/test_resource_extraction.py
@@ -822,6 +822,7 @@ def test_cli_box(runner, WindX_cls):
         assert np.allclose(site_df.values, truth.values)
 
     WindX_cls.close()
+    LOGGERS.clear()
 
 
 def execute_pytest(capture='all', flags='-rapP'):

--- a/tests/test_resource_extraction.py
+++ b/tests/test_resource_extraction.py
@@ -21,6 +21,7 @@ from rex.resource_extraction.resource_extraction import (MultiFileWindX,
                                                          NSRDBX, WindX, WaveX)
 from rex.resource_extraction.resource_extraction import TREE_DIR
 from rex.utilities.exceptions import ResourceValueError
+from rex.utilities.loggers import LOGGERS
 from rex import TESTDATADIR
 
 
@@ -733,6 +734,7 @@ def test_cli_site(runner, WindX_cls):
         assert np.allclose(site_df.values, truth.values)
 
     WindX_cls.close()
+    LOGGERS.clear()
 
 
 def test_cli_SAM(runner, WindX_cls):
@@ -761,6 +763,7 @@ def test_cli_SAM(runner, WindX_cls):
         assert_frame_equal(truth, test)
 
     WindX_cls.close()
+    LOGGERS.clear()
 
 
 def test_cli_region(runner, WindX_cls):
@@ -789,6 +792,7 @@ def test_cli_region(runner, WindX_cls):
         assert np.allclose(site_df.values, truth.values)
 
     WindX_cls.close()
+    LOGGERS.clear()
 
 
 def test_cli_box(runner, WindX_cls):

--- a/tests/test_temporal_stats.py
+++ b/tests/test_temporal_stats.py
@@ -15,6 +15,7 @@ from rex.multi_year_resource import MultiYearWindResource
 from rex.renewable_resource import WindResource
 from rex.resource_extraction.temporal_stats import TemporalStats
 from rex.resource_extraction.temporal_stats_cli import main
+from rex.utilities.loggers import LOGGERS
 from rex import TESTDATADIR
 
 PURGE_OUT = True
@@ -266,6 +267,9 @@ def test_cli(runner):
         truth = np.mean(res_data[mask], axis=0)
         msg = 'January-midnight means do not match!'
         assert np.allclose(truth, test_stats['Jan-00_mean'].values), msg
+
+
+LOGGERS.clear()
 
 
 def execute_pytest(capture='all', flags='-rapP'):

--- a/tests/test_temporal_stats.py
+++ b/tests/test_temporal_stats.py
@@ -268,8 +268,7 @@ def test_cli(runner):
         msg = 'January-midnight means do not match!'
         assert np.allclose(truth, test_stats['Jan-00_mean'].values), msg
 
-
-LOGGERS.clear()
+    LOGGERS.clear()
 
 
 def execute_pytest(capture='all', flags='-rapP'):


### PR DESCRIPTION
@grantbuster and @kdheepak
I ran into some funky ass logging issue when refactoring reVX for CLI tests so I decided to take a swing and cleaning up our logging methodology namely with a focus on fixing duplicate logging.

Changes here are:
1) In setup_logger check to see if the log_dir exists, if not warn the user and add a stream handler instead
2) Make it possible to setup init_multi without a log dir
3) Fix the handler checking logic. Now each handler has a name (stream or the log file) if a handler with the same name exists a new handler is not added, BUT the log level is checked and increased if needed
4) This was the biggest and hairiest one that I could take or leave. There is now logic to remove any children loggers from the LOGGERS registry and to remove any handlers from children loggers if a parent logger is initialized. 
- The upside here is that it prevents duplicate logging every time
- The downside is that the log levels get a bit confusing. I had to remove the default logger.setLevel("DEBUG") because all children always logged debug messages, but I think I was seeing this earlier too. 

In a nutshell logging propagation is a blessing and a curse... 