### PR TITLE
don't unscale datasets that don't have the proper attributes

### DIFF
--- a/rex/resource.py
+++ b/rex/resource.py
@@ -35,6 +35,8 @@ class ResourceDataset:
         self._scale_factor = self.ds.attrs.get(scale_attr, 1)
         self._adder = self.ds.attrs.get(add_attr, 0)
         self._unscale = unscale
+        if self._scale_factor == 1 and self._adder == 0:
+            self._unscale = False
 
     def __repr__(self):
         msg = "{} for {}".format(self.__class__.__name__, self.ds.name)

--- a/rex/version.py
+++ b/rex/version.py
@@ -1,3 +1,3 @@
 """rex Version number"""
 
-__version__ = "0.2.41"
+__version__ = "0.2.42"


### PR DESCRIPTION
@grantbuster  any concerns with this tweak? I ran into an issue where Resource converts integers to float32 when "scale_factor' isn't' given, which is silly on multiple levels... 