### PR TITLE
Special characters removed from meta info when making SAM files

### DIFF
--- a/rex/resource_extraction/resource_extraction.py
+++ b/rex/resource_extraction/resource_extraction.py
@@ -503,7 +503,7 @@ class ResourceX:
         site_meta = site_meta.rename(columns=col_map)
         cols = ','.join(site_meta.columns)
         values = ','.join(site_meta.values[0].astype(str))
-        values = values.replace('\n','')
+        values = values.replace('\n', '')
 
         with open(out_path, 'r+') as f:
             content = f.read()

--- a/rex/resource_extraction/resource_extraction.py
+++ b/rex/resource_extraction/resource_extraction.py
@@ -503,7 +503,7 @@ class ResourceX:
         site_meta = site_meta.rename(columns=col_map)
         cols = ','.join(site_meta.columns)
         values = ','.join(site_meta.values[0].astype(str))
-        values = values.replace('\n', '')
+        values = values.replace('\n', '').replace('\r', '').replace('\t', '')
 
         with open(out_path, 'r+') as f:
             content = f.read()

--- a/rex/resource_extraction/resource_extraction.py
+++ b/rex/resource_extraction/resource_extraction.py
@@ -503,6 +503,7 @@ class ResourceX:
         site_meta = site_meta.rename(columns=col_map)
         cols = ','.join(site_meta.columns)
         values = ','.join(site_meta.values[0].astype(str))
+        values = values.replace('\n','')
 
         with open(out_path, 'r+') as f:
             content = f.read()


### PR DESCRIPTION
The characters `'\n'`, `'\r'`, `'\t'` are removed from the meta values before writing the meta header.