### PR TITLE
Provide a more meaningful error if the name is bad

### DIFF
--- a/rex/rechunk_h5/rechunk_h5.py
+++ b/rex/rechunk_h5/rechunk_h5.py
@@ -557,6 +557,15 @@ class RechunkH5:
 
         name = dset_attrs.get('name', None)
         if name is not None:
+            if name is not str:
+                msg = ("dataset attribute `name` (value: {}, type: {}) must "
+                    "be a string. "
+                    "Check the attributes of the dataset ({}). If using an external "
+                    "json file for variable attributes, it might be using"
+                    " `null` for the name."
+                    .format(name, type(name), dset_name))
+                logger.error(msg)
+                raise RuntimeError(msg)
             dset_name = name
 
         logger.debug('Creating {} with shape: {}, dtype: {}, chunks: {}'


### PR DESCRIPTION
This provides a more meaningful error message if the name is bad along with some help to possibly debug the issue.