### PR TITLE
Added error messages if missing required SAM variable

### DIFF
--- a/.github/linters/.python-lint
+++ b/.github/linters/.python-lint
@@ -156,6 +156,7 @@ disable=
         unexpected-keyword-arg,
         no-value-for-parameter,
         too-many-lines,
+        arguments-renamed,
         arguments-differ,
         import-outside-toplevel,
         super-init-not-called,

--- a/.pylintrc
+++ b/.pylintrc
@@ -156,6 +156,7 @@ disable=
         unexpected-keyword-arg,
         no-value-for-parameter,
         too-many-lines,
+        arguments-renamed,
         arguments-differ,
         import-outside-toplevel,
         super-init-not-called,

--- a/rex/renewable_resource.py
+++ b/rex/renewable_resource.py
@@ -6,13 +6,18 @@ import numpy as np
 import os
 import pandas as pd
 import warnings
+import logging
 
 from rex.resource import BaseResource
 from rex.sam_resource import SAMResource
 from rex.utilities.exceptions import (ResourceValueError, ExtrapolationWarning,
                                       ResourceWarning, ResourceRuntimeError,
+                                      ResourceKeyError,
                                       MoninObukhovExtrapolationError)
 from rex.utilities.parse_keys import parse_keys
+
+
+logger = logging.getLogger(__name__)
 
 
 class SolarResource(BaseResource):
@@ -97,6 +102,7 @@ class SolarResource(BaseResource):
             Boolean flag to pull clearsky instead of real irradiance
         bifacial : bool
             Boolean flag to pull surface albedo for bifacial modeling.
+
         Returns
         -------
         SAM_res : SAMResource
@@ -433,6 +439,17 @@ class WindResource(BaseResource):
                         heights[ds_name].append(h)
 
             self._heights = heights
+
+            missing = []
+            for dset, h_vals in heights.items():
+                if not h_vals:
+                    missing.append(dset)
+
+            if missing:
+                msg = ("Missing height info for dataset(s): {} in {}"
+                       .format(missing, self.h5_file))
+                logger.error(msg)
+                raise ResourceKeyError(msg)
 
         return self._heights
 

--- a/rex/renewable_resource.py
+++ b/rex/renewable_resource.py
@@ -440,17 +440,6 @@ class WindResource(BaseResource):
 
             self._heights = heights
 
-            missing = []
-            for dset, h_vals in heights.items():
-                if not h_vals:
-                    missing.append(dset)
-
-            if missing:
-                msg = ("Missing height info for dataset(s): {} in {}"
-                       .format(missing, self.h5_file))
-                logger.error(msg)
-                raise ResourceKeyError(msg)
-
         return self._heights
 
     @staticmethod
@@ -865,7 +854,7 @@ class WindResource(BaseResource):
     def _get_ds_height(self, ds_name, ds_slice):
         """
         Extract data from given dataset at desired height, interpolate or
-        extrapolate if neede
+        extrapolate if needed.
 
         Parameters
         ----------
@@ -884,7 +873,12 @@ class WindResource(BaseResource):
         var_name, h = self._parse_name(ds_name)
         heights = self.heights[var_name]
 
-        if h in heights:
+        if not heights:
+            msg = ("Missing height info for dataset '{}' in {}"
+                   .format(var_name, self.h5_file))
+            logger.error(msg)
+            raise ResourceKeyError(msg)
+        elif h in heights:
             ds_name = '{}_{}m'.format(var_name, int(h))
             out = super()._get_ds(ds_name, ds_slice)
         elif len(heights) == 1:

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -658,7 +658,7 @@ def test_missing_dset():
         with WindResource_res() as res:
             __ = res['pressure_150m']
 
-    assert 'dne_dset not in' in str(excinfo.value)
+    assert 'pressure_150m not in' in str(excinfo.value)
 
 
 def test_missing_dset_for_heights():

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -648,6 +648,17 @@ def test_group_raise():
             check_res(res)
 
 
+def test_missing_dset():
+    """
+    test WindResource missing data set
+    """
+    with pytest.raises(ResourceKeyError) as excinfo:
+        with WindResource_res() as res:
+            __ = res['pressure_150m']
+
+    assert 'dne_dset not in' in str(excinfo.value)
+
+
 def test_check_files():
     """
     test MultiH5 check_files

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -8,6 +8,8 @@ import numpy as np
 import os
 import pandas as pd
 import pytest
+import shutil
+import tempfile
 
 from rex import TESTDATADIR
 from rex.multi_file_resource import (MultiH5, MultiH5Path, MultiFileNSRDB,
@@ -657,6 +659,27 @@ def test_missing_dset():
             __ = res['pressure_150m']
 
     assert 'dne_dset not in' in str(excinfo.value)
+
+
+def test_missing_dset_for_heights():
+    """
+    test WindResource missing data set for `self.heights`
+    """
+    path = os.path.join(TESTDATADIR, 'wtk/ri_100_wtk_2012.h5')
+
+    with tempfile.TemporaryDirectory() as td:
+        res_fp = os.path.join(td, 'ri_100_wtk_2012.h5')
+        shutil.copy(path, res_fp)
+        with h5py.File(res_fp, 'a') as fh:
+            del fh['temperature_80m']
+            del fh['temperature_100m']
+
+        with pytest.raises(ResourceKeyError) as excinfo:
+            with WindResource(res_fp) as res:
+                __ = res.heights
+
+    expected_str = "Missing height info for dataset(s): ['temperature']"
+    assert expected_str in str(excinfo.value)
 
 
 def test_check_files():

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -656,9 +656,9 @@ def test_missing_dset():
     """
     with pytest.raises(ResourceKeyError) as excinfo:
         with WindResource_res() as res:
-            __ = res['pressure_150m']
+            __ = res['dne_dset']
 
-    assert 'pressure_150m not in' in str(excinfo.value)
+    assert 'dne_dset not in' in str(excinfo.value)
 
 
 def test_missing_dset_for_heights():
@@ -676,9 +676,9 @@ def test_missing_dset_for_heights():
 
         with pytest.raises(ResourceKeyError) as excinfo:
             with WindResource(res_fp) as res:
-                __ = res.heights
+                __ = res._get_ds_height('temperature', (0, 0))
 
-    expected_str = "Missing height info for dataset(s): ['temperature']"
+    expected_str = "Missing height info for dataset 'temperature'"
     assert expected_str in str(excinfo.value)
 
 


### PR DESCRIPTION
Added error message if missing a required SAM variable when retrieving a dataset using `self._get_ds_height`, as per #127. (See [failed tests](https://github.com/NREL/rex/runs/6499332299?check_suite_focus=true) to explain why we can't raise error in `self.heights`)

`preload_SAM` method error messages are covered by base class:
https://github.com/NREL/rex/blob/17392404b816c4c8f29cadc54adb3cf072fcbca7/rex/resource.py#L1247-L1249