### PR TITLE
Time index generalization

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 click>=7.0
+google-auth-oauthlib==0.5.3
 h5py>=2.10.0,!=3.0.0
 h5pyd>=0.7.0
 numpy>=1.16

--- a/rex/renewable_resource.py
+++ b/rex/renewable_resource.py
@@ -1013,8 +1013,9 @@ class WindResource(BaseResource):
         if add_header:
             header = pd.DataFrame(columns=res_df.columns)
             header_units = units + [self.get_units(v) for v in variables]
-            header.at[0, res_df.columns] = header_units
-            header.at[1, res_df.columns] = height
+            header_heights = [height] * len(header_units)
+            header = pd.DataFrame([header_units, header_heights],
+                                  columns=res_df.columns)
             res_df = pd.concat((header, res_df)).reset_index(drop=True)
 
         return res_df

--- a/rex/renewable_resource.py
+++ b/rex/renewable_resource.py
@@ -1012,8 +1012,9 @@ class WindResource(BaseResource):
 
         if add_header:
             header = pd.DataFrame(columns=res_df.columns)
-            header.at[0] = units + [self.get_units(v) for v in variables]
-            header.at[1] = height
+            header_units = units + [self.get_units(v) for v in variables]
+            header.at[0, res_df.columns] = header_units
+            header.at[1, res_df.columns] = height
             res_df = pd.concat((header, res_df)).reset_index(drop=True)
 
         return res_df

--- a/rex/resource.py
+++ b/rex/resource.py
@@ -7,6 +7,7 @@ import h5py
 import numpy as np
 import os
 import pandas as pd
+import dateutil
 
 from rex.sam_resource import SAMResource
 from rex.utilities.parse_keys import parse_keys, parse_slice
@@ -1140,10 +1141,12 @@ class BaseResource(ABC):
         time_index = self.h5[ds_name]
         time_index = ResourceDataset.extract(time_index, ds_slice[0],
                                              unscale=False)
+        try:
+            datetime_index = pd.to_datetime(time_index.astype(str))
+        except (pd.errors.OutOfBoundsDatetime, dateutil.parser.ParserError):
+            return time_index
 
-        time_index = check_tz(pd.to_datetime(time_index.astype(str)))
-
-        return time_index
+        return check_tz(datetime_index)
 
     def _get_meta(self, ds_name, ds_slice):
         """

--- a/rex/utilities/utilities.py
+++ b/rex/utilities/utilities.py
@@ -954,7 +954,7 @@ def to_records_array(df):
     """
     meta_arrays = []
     dtypes = []
-    for c_name, c_data in df.iteritems():
+    for c_name, c_data in df.items():
         dtype = get_dtype(c_data)
 
         if np.issubdtype(dtype, np.bytes_):

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -705,10 +705,9 @@ def test_time_index_out_of_bounds():
         chunks = {"data": None}
         dtypes = {"data": "float32"}
 
-        Outputs.init_h5(out_fp, ["data"], shapes,attrs, chunks, dtypes,
-            meta=pd.DataFrame(data={"lat": [0], "lon": [1]}),
-            time_index=time,
-        )
+        Outputs.init_h5(out_fp, ["data"], shapes, attrs, chunks, dtypes,
+                        meta=pd.DataFrame(data={"lat": [0], "lon": [1]}),
+                        time_index=time)
         with Outputs(out_fp, 'a') as out:
             out["data", :, 0] = time + 10
 


### PR DESCRIPTION
I'd like to use rex for some non-reV spatiotemporal data I/O (in particular, for the DayCent framework), but the data I am working with is outside of [pandas' timestamp limitations.](https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#timestamp-limitations) In this case, I'd like to relax the requirement that `Resource` time index is a `DatetimeIndex`. To be clear, `Resource` will still try to convert the time index data into a `DatetimeIndex`, but if that step fails, it will simply return the time-index data stored in the file instead of throwing an error. Let me know if there are any issues with this approach. I did consider attempting to put the data into a [`PeriodIndex`](https://pandas.pydata.org/docs/reference/api/pandas.PeriodIndex.html) as backup, but I think `Resource` would need to know too much about the time-index data format (i.e. is the data daily? hourly? Is it stored in YYYYMMDD format? etc.) in order to do that generally.

Also addressed this minor but annoying warning:
```
.../rex/utilities/utilities.py:957: FutureWarning: iteritems is deprecated and will be removed in a future version. Use .items instead.
     for c_name, c_data in df.iteritems():
```