### PR TITLE
1D dataset support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 click>=7.0
-google-auth-oauthlib==0.5.3
+google-auth-oauthlib<=0.5.3
 h5py>=2.10.0,!=3.0.0
 h5pyd>=0.7.0
 numpy>=1.16

--- a/rex/outputs.py
+++ b/rex/outputs.py
@@ -664,17 +664,21 @@ class Outputs(BaseResource):
         """
         dset_shape = dset_data.shape
         if len(dset_shape) == 1:
-            shape = len(self.meta)
-            if shape:
-                shape = (shape,)
-                if dset_shape != shape:
-                    msg = ('1D dataset "{}" with shape {} is not of '
-                           'the proper spatial shape: {}'
-                           .format(dset_name, dset_shape, shape))
-                    logger.error(msg)
-                    raise HandlerValueError(msg)
-            else:
+            spatial_shape = len(self.meta)
+            if not spatial_shape:
                 raise HandlerRuntimeError("'meta' has not been loaded")
+            temporal_shape = len(self.time_index)
+            if not temporal_shape:
+                raise HandlerRuntimeError("'time_index' has not been loaded")
+
+            spatial_shape, temporal_shape = (spatial_shape,), (temporal_shape,)
+            if dset_shape not in {spatial_shape, temporal_shape}:
+                msg = ('1D dataset "{}" with shape {} is not of '
+                       'the proper spatial {} or temporal {} shape!'
+                       .format(dset_name, dset_shape, spatial_shape,
+                               temporal_shape))
+                logger.error(msg)
+                raise HandlerValueError(msg)
         else:
             shape = self.shape
             if shape:

--- a/rex/resource.py
+++ b/rex/resource.py
@@ -1282,7 +1282,9 @@ class BaseResource(ABC):
             ndarray of variable timeseries data
             If unscale, returned in native units else in scaled units
         """
-        if self.shapes['meta'] == self.shapes['time_index']:
+        ti_shape = self.shapes.get('time_index')
+        meta_shape = self.shapes.get('meta')
+        if ti_shape == meta_shape:
             msg = ("Attempting to use a 2D slice on a 1D dataset when the "
                    "meta and time index have the same shape - unable to "
                    "disambiguate the slice dimensions. Please either update "
@@ -1291,9 +1293,9 @@ class BaseResource(ABC):
                    "1-dimensional slice.".format(ds_name, ds.shape))
             raise ResourceRuntimeError(msg)
 
-        if ds.shape == self.shapes['time_index']:
+        if ds.shape == ti_shape:
             return self._get_ds_with_spatial_repeat(ds, ds_name, ds_slice)
-        if ds.shape == self.shapes['meta']:
+        if ds.shape == meta_shape:
             return self._get_ds_with_temporal_repeat(ds, ds_name, ds_slice)
 
         msg = ("Attempting to use a 2D slice on a 1D dataset ({0!r}) when "
@@ -1301,8 +1303,7 @@ class BaseResource(ABC):
                "of the meta {2!r})or the time index {3!r}. Please either "
                "update the length of ({0!r}) to match either the meta or "
                "index, or use a 1-dimensional slice."
-               .format(ds_name, ds.shape, self.shapes['meta'],
-                       self.shapes['time_index']))
+               .format(ds_name, ds.shape, meta_shape, ti_shape))
         raise ResourceRuntimeError(msg)
 
     def _get_ds_with_spatial_repeat(self, ds, ds_name, ds_slice):

--- a/rex/resource.py
+++ b/rex/resource.py
@@ -1336,12 +1336,12 @@ class BaseResource(ABC):
                                       scale_attr=self.SCALE_ATTR,
                                       add_attr=self.ADD_ATTR,
                                       unscale=self._unscale)
-        try:
+        if not isinstance(out, np.ndarray):
+            out *= np.ones(self.shapes['meta'], dtype=np.float32)
+            out = out[ds_slice[1]]
+        else:
             out = np.repeat(out[:, None], self.shapes['meta'][0], axis=1)
             out = out[:, ds_slice[1]]
-        except (TypeError, IndexError):  # "out" is an int, float, etc.
-            out = np.ones(self.shapes['meta']) * out
-            out = out[ds_slice[1]]
 
         return out.astype(np.float32)
 
@@ -1375,10 +1375,12 @@ class BaseResource(ABC):
                                       scale_attr=self.SCALE_ATTR,
                                       add_attr=self.ADD_ATTR,
                                       unscale=self._unscale)
-        try:
+
+        if not isinstance(out, np.ndarray):
+            out *= np.ones(self.shapes['time_index'], dtype=np.float32)
+        else:
             out = np.ones((self.shapes['time_index'][0], len(out))) * out
-        except TypeError: # "out" is an int, float, etc.
-            out = np.ones(self.shapes['time_index']) * out
+
         return out[ds_slice[0]].astype(np.float32)
 
     def close(self):

--- a/rex/resource.py
+++ b/rex/resource.py
@@ -1216,7 +1216,7 @@ class BaseResource(ABC):
                                          unscale=False)
         return coords
 
-    # pylint: disable=unused-argument,no-self-use
+    # pylint: disable=unused-argument
     def get_SAM_df(self, site):
         """
         Placeholder for get_SAM_df method that it resource specific

--- a/rex/resource.py
+++ b/rex/resource.py
@@ -1337,11 +1337,13 @@ class BaseResource(ABC):
                                       add_attr=self.ADD_ATTR,
                                       unscale=self._unscale)
         try:
-            out = (np.ones((len(out), self.shapes['meta'][0])).T * out).T
-            return out[:, ds_slice[1]]
-        except TypeError:
+            out = np.repeat(out[:, None], self.shapes['meta'][0], axis=1)
+            out = out[:, ds_slice[1]]
+        except (TypeError, IndexError):  # "out" is an int, float, etc.
             out = np.ones(self.shapes['meta']) * out
-            return out[ds_slice[1]]
+            out = out[ds_slice[1]]
+
+        return out.astype(np.float32)
 
     def _get_ds_with_temporal_repeat(self, ds, ds_name, ds_slice):
         """
@@ -1375,9 +1377,9 @@ class BaseResource(ABC):
                                       unscale=self._unscale)
         try:
             out = np.ones((self.shapes['time_index'][0], len(out))) * out
-        except TypeError:
+        except TypeError: # "out" is an int, float, etc.
             out = np.ones(self.shapes['time_index']) * out
-        return out[ds_slice[0]]
+        return out[ds_slice[0]].astype(np.float32)
 
     def close(self):
         """

--- a/tests/test_outputs.py
+++ b/tests/test_outputs.py
@@ -10,7 +10,7 @@ import os
 import tempfile
 
 from rex.version import __version__
-from rex import Outputs
+from rex import Outputs, Resource
 from rex.utilities.exceptions import HandlerRuntimeError, HandlerValueError
 
 
@@ -144,6 +144,24 @@ def test_bad_shape():
         with pytest.raises(HandlerValueError):
             Outputs.add_dataset(fp, 'dset3', np.ones((10, 10)), float,
                                 attrs=None)
+
+
+def test_1D_dataset_shape():
+    """Negative test for bad data shapes"""
+
+    with tempfile.TemporaryDirectory() as td:
+        fp = os.path.join(td, 'outputs.h5')
+
+        with Outputs(fp, 'w') as f:
+            f.meta = meta
+            f.time_index = time_index
+
+        Outputs.add_dataset(fp, 'dset3', np.ones(100), float, attrs=None,
+                            chunks=(100,))
+
+        with Resource(fp) as res:
+            assert 'dset3' in res.dsets
+            assert res['dset3'].shape == (100,)
 
 
 def execute_pytest(capture='all', flags='-rapP'):

--- a/tests/test_outputs.py
+++ b/tests/test_outputs.py
@@ -153,26 +153,26 @@ def test_1d_datasets_not_added_before_meta_ti():
 
         with Outputs(fp, 'w') as f:
             pass
-        with pytest.raises(ResourceKeyError):
+        with pytest.raises(HandlerRuntimeError):
             Outputs.add_dataset(
                 fp, 'dset3', np.ones(10), float, attrs=None
             )
         with Outputs(fp, 'w') as f:
             f.meta = meta
-        with pytest.raises(ResourceKeyError):
+        with pytest.raises(HandlerValueError):
             Outputs.add_dataset(
                 fp, 'dset3', np.ones(10), float, attrs=None
             )
         with Outputs(fp, 'w') as f:
             f.time_index = time_index
-        with pytest.raises(ResourceKeyError):
+        with pytest.raises(HandlerValueError):
             Outputs.add_dataset(
                 fp, 'dset3', np.ones(10), float, attrs=None
             )
         with Outputs(fp, 'w') as f:
             f.meta = np.empty((0))
             f.time_index = np.empty((0))
-        with pytest.raises(HandlerRuntimeError):
+        with pytest.raises(HandlerValueError):
             Outputs.add_dataset(
                 fp, 'dset3', np.ones(10), float, attrs=None
             )
@@ -180,7 +180,15 @@ def test_1d_datasets_not_added_before_meta_ti():
         with Outputs(fp, 'w') as f:
             f.meta = meta
             f.time_index = np.empty((0))
-        with pytest.raises(HandlerRuntimeError):
+        with pytest.raises(HandlerValueError):
+            Outputs.add_dataset(
+                fp, 'dset3', np.ones(10), float, attrs=None
+            )
+
+        with Outputs(fp, 'w') as f:
+            f.meta = np.empty((0))
+            f.time_index = time_index
+        with pytest.raises(HandlerValueError):
             Outputs.add_dataset(
                 fp, 'dset3', np.ones(10), float, attrs=None
             )
@@ -207,6 +215,32 @@ def test_1D_dataset_shape():
 
         with Outputs(fp, 'w') as f:
             f.meta = meta
+            f.time_index = time_index
+
+        Outputs.add_dataset(fp, 'dset3', np.ones(8760), float, attrs=None,
+                            chunks=(100,))
+
+        with Resource(fp) as res:
+            assert 'dset3' in res.dsets
+            assert res['dset3'].shape == (8760,)
+
+    with tempfile.TemporaryDirectory() as td:
+        fp = os.path.join(td, 'outputs.h5')
+
+        with Outputs(fp, 'w') as f:
+            f.meta = meta
+
+        Outputs.add_dataset(fp, 'dset3', np.ones(100), float, attrs=None,
+                            chunks=(100,))
+
+        with Resource(fp) as res:
+            assert 'dset3' in res.dsets
+            assert res['dset3'].shape == (100,)
+
+    with tempfile.TemporaryDirectory() as td:
+        fp = os.path.join(td, 'outputs.h5')
+
+        with Outputs(fp, 'w') as f:
             f.time_index = time_index
 
         Outputs.add_dataset(fp, 'dset3', np.ones(8760), float, attrs=None,

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -716,6 +716,49 @@ def test_time_index_out_of_bounds():
             assert np.allclose(res["data"][:, 0], time + 10)
 
 
+def test_5D_dataset_slicing():
+    """Test that slices into 5D datasets work as expected. """
+    meta = pd.DataFrame({'latitude': np.ones(100),
+                         'longitude': np.zeros(100)})
+    time_index = pd.date_range('20210101', '20220101', freq='1D',
+                               closed='right')
+    with tempfile.TemporaryDirectory() as td:
+        fp = os.path.join(td, 'outputs.h5')
+
+        with Outputs(fp, 'w') as f:
+            f.meta = meta.iloc[0:3]
+            f.time_index = time_index[0:3]
+
+        data = np.arange(243).reshape(3, 3, 3, 3, 3)
+        with h5py.File(fp, mode="a") as h5:
+            h5.create_dataset('dset3', shape=data.shape, dtype=np.float32,
+                              chunks=(1, 1, 1, 1, 1), data=data)
+
+        with Resource(fp) as res:
+            assert 'dset3' in res.dsets
+            assert res['dset3'].shape == (3, 3, 3, 3, 3)
+            assert res['dset3'].dtype == np.float32
+            assert np.allclose(res['dset3'], data)
+            assert np.allclose(res['dset3', 1], data[1])
+            assert np.allclose(res['dset3', 0, 1], data[0, 1])
+            assert np.allclose(res['dset3', 0, 1, 2], data[0, 1, 2])
+            assert np.allclose(res['dset3', 0, 1, 2, 0], data[0, 1, 2, 0])
+            assert np.allclose(res['dset3', 0, 1, 2, 0, 1],
+                               data[0, 1, 2, 0, 1])
+            assert np.allclose(res['dset3', 1:], data[1:])
+            assert np.allclose(res['dset3', 0:, 1], data[0:, 1])
+            assert np.allclose(res['dset3', 0:, 1:, 2], data[0:, 1:, 2])
+            assert np.allclose(res['dset3', 0:, 1:, 2:, 0],
+                               data[0:, 1:, 2:, 0])
+            assert np.allclose(res['dset3', 0:, 1:, 2:, 0:, 1],
+                               data[0:, 1:, 2:, 0:, 1])
+            assert np.allclose(res['dset3', 0:, 1:, 2:, 0:, 1:],
+                               data[0:, 1:, 2:, 0:, 1:])
+            assert np.allclose(res['dset3', ..., 0], data[..., 0])
+            assert np.allclose(res['dset3', :, :, :, :, 1],
+                               data[:, :, :, :, 1])
+
+
 def test_bad_1D_dataset_slicing():
     """Test that 2D slices into 1D datasets raise errors as expected. """
     meta = pd.DataFrame({'latitude': np.ones(100),
@@ -729,12 +772,13 @@ def test_bad_1D_dataset_slicing():
         with Outputs(fp, 'w') as f:
             f.meta = meta
             f.time_index = time_index[0:100]
-        Outputs.add_dataset(fp, 'dset3', np.ones(100), float, attrs=None,
+        Outputs.add_dataset(fp, 'dset3', np.ones(100), np.float32, attrs=None,
                             chunks=(100,))
 
         with Resource(fp) as res:
             assert 'dset3' in res.dsets
             assert res['dset3'].shape == (100,)
+            assert res['dset3'].dtype == np.float32
             assert np.allclose(res['dset3'], 1)
             assert np.allclose(res['dset3', 0:10], 1)
             with pytest.raises(ResourceRuntimeError):
@@ -767,24 +811,29 @@ def test_1D_dataset_slicing_temporal_repeat():
             f.meta = meta
             f.time_index = time_index
 
-        Outputs.add_dataset(fp, 'dset3', np.arange(100), float, attrs=None,
-                            chunks=(100,))
+        Outputs.add_dataset(fp, 'dset3', np.arange(100), np.float32,
+                            attrs=None, chunks=(100,))
 
         with Resource(fp) as res:
             assert 'dset3' in res.dsets
             assert res['dset3'].shape == (100,)
+            assert res['dset3'].dtype == np.float32
             assert np.allclose(res['dset3'], np.arange(100))
             assert np.allclose(res['dset3', 1], 1)
+            assert res['dset3', 1].dtype == np.float32
             assert np.allclose(res['dset3', [50, 75, 23]], [50, 75, 23])
+            assert res['dset3', [50, 75, 23]].dtype == np.float32
 
             with pytest.warns(UserWarning):
                 data = res['dset3', :, 99]
             assert data.shape == (365,)
+            assert data.dtype == np.float32
             assert np.allclose(data, 99)
 
             with pytest.warns(UserWarning):
                 data = res['dset3', :, [50, 75, 23]]
             assert data.shape == (365, 3)
+            assert data.dtype == np.float32
             assert np.allclose(data[:, 0], 50)
             assert np.allclose(data[:, 1], 75)
             assert np.allclose(data[:, 2], 23)
@@ -792,11 +841,13 @@ def test_1D_dataset_slicing_temporal_repeat():
             with pytest.warns(UserWarning):
                 data = res['dset3', 10:20, :]
             assert data.shape == (10, 100)
+            assert data.dtype == np.float32
             for t_ind in range(10):
                 assert np.allclose(data[t_ind], np.arange(100))
 
             with pytest.warns(UserWarning):
                 assert res['dset3', 55, 79] == 79
+                assert res['dset3', 55, 79].dtype == np.float32
 
 
 def test_1D_dataset_slicing_spatial_repeat():
@@ -812,24 +863,29 @@ def test_1D_dataset_slicing_spatial_repeat():
             f.meta = meta
             f.time_index = time_index
 
-        Outputs.add_dataset(fp, 'dset3', np.arange(365), float, attrs=None,
-                            chunks=(100,))
+        Outputs.add_dataset(fp, 'dset3', np.arange(365), np.float32,
+                            attrs=None, chunks=(100,))
 
         with Resource(fp) as res:
             assert 'dset3' in res.dsets
             assert res['dset3'].shape == (365,)
+            assert res['dset3'].dtype == np.float32
             assert np.allclose(res['dset3'], np.arange(365))
             assert np.allclose(res['dset3', 1], 1)
+            assert res['dset3', 1].dtype == np.float32
             assert np.allclose(res['dset3', [50, 75, 23]], [50, 75, 23])
+            assert res['dset3', [50, 75, 23]].dtype == np.float32
 
             with pytest.warns(UserWarning):
                 data = res['dset3', 99, :]
             assert data.shape == (100,)
+            assert data.dtype == np.float32
             assert np.allclose(data, 99)
 
             with pytest.warns(UserWarning):
                 data = res['dset3', [50, 75, 23], :]
             assert data.shape == (3, 100)
+            assert data.dtype == np.float32
             assert np.allclose(data[0], 50)
             assert np.allclose(data[1], 75)
             assert np.allclose(data[2], 23)
@@ -837,11 +893,13 @@ def test_1D_dataset_slicing_spatial_repeat():
             with pytest.warns(UserWarning):
                 data = res['dset3', :, 10:20]
             assert data.shape == (365, 10)
+            assert data.dtype == np.float32
             for s_ind in range(10):
                 assert np.allclose(data[:, s_ind], np.arange(365))
 
             with pytest.warns(UserWarning):
                 assert res['dset3', 55, 79] == 55
+                assert res['dset3', 55, 79].dtype == np.float32
 
 
 def execute_pytest(capture='all', flags='-rapP'):


### PR DESCRIPTION
Added support for 1D datasets in spatiotemporal resource files. The 1D datasets MUST have the same shape as either the time index or the meta, otherwise an error is raised when trying to write to file using `Outputs`.  Reading the 1D dataset is supported in multiple ways:

- A simple 1D slice into the data will return a 1D array corresponding to the slice.
- A 2D slice will cause the 1D data to be repeated in either the spatial or temporal dimension. A warning is raised in either case, explaining to the user what is happening. The data is repeated in the spatial dimension if the 1D shape matches the shape of the time index, otherwise it is repeated in the temporal dimension.

I have verified that this change is compatible with reV using the WTK2.0 data.