### PR TITLE
Added Python 3.10 support

### DIFF
--- a/.github/workflows/pull_request_tests.yml
+++ b/.github/workflows/pull_request_tests.yml
@@ -9,8 +9,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.9]
+        python-version: ['3.10']
         include:
+          - os: ubuntu-latest
+            python-version: 3.9
           - os: ubuntu-latest
             python-version: 3.8
           - os: ubuntu-latest

--- a/rex/version.py
+++ b/rex/version.py
@@ -1,3 +1,3 @@
 """rex Version number"""
 
-__version__ = "0.2.74"
+__version__ = "0.2.75"

--- a/setup.py
+++ b/setup.py
@@ -82,6 +82,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9"
+        "Programming Language :: Python :: 3.10"
     ],
     test_suite="tests",
     install_requires=install_requires,


### PR DESCRIPTION
Just extended the tests to include 3.10 :)

This update is part of a broader effort of updating reV to PySAM 3 and therefore allowing the whole reV suite to support Python 3.10