### PR TITLE
Geothermal resource

### DIFF
--- a/.github/workflows/pr_revx_tests.yml
+++ b/.github/workflows/pr_revx_tests.yml
@@ -33,7 +33,8 @@ jobs:
       working-directory: ./reVX
       shell: bash -l {0}
       run: |
-        conda install rtree geopandas
+        conda install rtree pytest
+        pip install geopandas
         pip install --upgrade --force-reinstall shapely~=1.8
         pip install -e .
         pip install HOPP
@@ -41,5 +42,4 @@ jobs:
       working-directory: ./reVX
       shell: bash -l {0}
       run: |
-        conda install pytest
         pytest -v --disable-warnings

--- a/rex/__init__.py
+++ b/rex/__init__.py
@@ -16,7 +16,8 @@ from rex.multi_year_resource import (MultiYearNSRDB, MultiYearResource,
                                      MultiYearWindResource)
 from rex.rechunk_h5 import (ArrayChunkSize, TimeseriesChunkSize, CombineH5,
                             RechunkH5, get_dataset_attributes)
-from rex.renewable_resource import NSRDB, WaveResource, WindResource
+from rex.renewable_resource import (NSRDB, WaveResource, WindResource,
+                                    GeothermalResource)
 from rex.resource_extraction import (ResourceX, MultiFileResourceX,
                                      MultiTimeResourceX, MultiYearResourceX,
                                      NSRDBX, MultiFileNSRDBX,

--- a/rex/multi_file_resource.py
+++ b/rex/multi_file_resource.py
@@ -554,7 +554,8 @@ class MultiFileWTK(MultiFileResource, WindResource):
         """
         super().__init__(h5_source, unscale=unscale, str_decode=str_decode,
                          check_files=check_files)
-        self._heights = None
+        self._interp_var = None
+        self.heights = self._interpolation_variable
 
     @classmethod
     def preload_SAM(cls, h5_source, sites, hub_heights, unscale=True,

--- a/rex/renewable_resource.py
+++ b/rex/renewable_resource.py
@@ -569,8 +569,8 @@ class AbstractInterpolatedResource(BaseResource):
         if extrapolate:
             v_min, v_max = np.sort(vals)[[0, -1]]
             msg = ('{} is outside the {} range'.format(val, cls.VARIABLE_NAME),
-                    '({}, {}).'.format(v_min, v_max),
-                    'Extrapolation to be used.')
+                   '({}, {}).'.format(v_min, v_max),
+                   'Extrapolation to be used.')
             warnings.warn(' '.join(msg), ExtrapolationWarning)
 
         return nearest_d, extrapolate
@@ -705,7 +705,7 @@ class AbstractInterpolatedResource(BaseResource):
 
         if extrapolate:
             msg = ('Extrapolating {} using linear extrapolation'
-                    .format(ds_name))
+                   .format(ds_name))
             warnings.warn(msg, ExtrapolationWarning)
 
         dset_name_1 = '{}_{}{}'.format(var_name, v1, self.VARIABLE_UNIT)

--- a/rex/sam_resource.py
+++ b/rex/sam_resource.py
@@ -113,7 +113,7 @@ class SAMResource:
                    'wave': WAVE_DATA_RANGES,
                    'geothermal': GEOTHERMAL_DATA_RANGES}
 
-    def __init__(self, sites, tech, time_index, hub_heights=None,
+    def __init__(self, sites, tech, time_index, hub_heights=None, depths=None,
                  require_wind_dir=False, means=False):
         """
         Parameters
@@ -126,6 +126,8 @@ class SAMResource:
             Time-series datetime index
         hub_heights : int | float | list, optional
             Hub height(s) to extract wind data at, by default None
+        depths : int | float | list, optional
+            Depth(s) to extract wind data at, by default None
         require_wind_dir : bool, optional
             Boolean flag indicating that wind direction is required,
             by default False
@@ -143,6 +145,7 @@ class SAMResource:
         self._runnable = False
         self._res_arrays = {}
         self._h = hub_heights
+        self._d = depths
         self._sza = None
 
         self._mean_arrays = None
@@ -364,9 +367,21 @@ class SAMResource:
         Returns
         -------
         self._h : int | float | list
-            Hub height or height(s) for wind resource, None for solar resource
+            Hub height or height(s) for wind resource, None for other resource
         """
         return self._h
+
+    @property
+    def d(self):
+        """
+        Get depths for geothermal sites
+
+        Returns
+        -------
+        self._d : int | float | list
+            Depth(s) for geothermal resource, None for other resource
+        """
+        return self._d
 
     @property
     def lat_lon(self):

--- a/rex/sam_resource.py
+++ b/rex/sam_resource.py
@@ -50,7 +50,10 @@ class SAMResource:
                          'windspeed'),
                 'windpower': ('pressure', 'temperature', 'winddirection',
                               'windspeed'),
-                'wave': ('significant_wave_height', 'energy_period')}
+                'wave': ('significant_wave_height', 'energy_period'),
+                # geothermal module uses hourly solar data
+                'geothermal': ('dni', 'dhi', 'ghi', 'wind_speed',
+                               'air_temperature')}
 
     # valid data ranges for PV solar resource:
     PV_DATA_RANGES = {'dni': (0.0, 1360.0),
@@ -105,7 +108,9 @@ class SAMResource:
                    'troughphysicalheat': TPPH_DATA_RANGES,
                    'lineardirectsteam': LF_DATA_RANGES,
                    'solarwaterheat': SWH_DATA_RANGES,
-                   'wave': WAVE_DATA_RANGES}
+                   'wave': WAVE_DATA_RANGES,
+                   # geothermal module uses hourly solar data
+                   'geothermal': PV_DATA_RANGES}
 
     def __init__(self, sites, tech, time_index, hub_heights=None,
                  require_wind_dir=False, means=False):

--- a/rex/sam_resource.py
+++ b/rex/sam_resource.py
@@ -51,9 +51,7 @@ class SAMResource:
                 'windpower': ('pressure', 'temperature', 'winddirection',
                               'windspeed'),
                 'wave': ('significant_wave_height', 'energy_period'),
-                # geothermal module uses hourly solar data
-                'geothermal': ('dni', 'dhi', 'ghi', 'wind_speed',
-                               'air_temperature')}
+                'geothermal': ('temperature', 'potential_MW')}
 
     # valid data ranges for PV solar resource:
     PV_DATA_RANGES = {'dni': (0.0, 1360.0),
@@ -96,6 +94,10 @@ class SAMResource:
     # valid data ranges for solar water heater
     SWH_DATA_RANGES = CSP_DATA_RANGES
 
+    # valid data ranges for solar water heater
+    GEOTHERMAL_DATA_RANGES = {'temperature': (-200, 1000),
+                              'potential_MW': (0, 10000)}
+
     # Data range mapping by SAM tech string
     DATA_RANGES = {'windpower': WIND_DATA_RANGES,
                    'wind': WIND_DATA_RANGES,
@@ -109,8 +111,7 @@ class SAMResource:
                    'lineardirectsteam': LF_DATA_RANGES,
                    'solarwaterheat': SWH_DATA_RANGES,
                    'wave': WAVE_DATA_RANGES,
-                   # geothermal module uses hourly solar data
-                   'geothermal': PV_DATA_RANGES}
+                   'geothermal': GEOTHERMAL_DATA_RANGES}
 
     def __init__(self, sites, tech, time_index, hub_heights=None,
                  require_wind_dir=False, means=False):

--- a/rex/sam_resource.py
+++ b/rex/sam_resource.py
@@ -479,7 +479,7 @@ class SAMResource:
                 # convert pressure from Pa to hPa
                 var_array /= 100
 
-        elif 'temperature' in var_name:
+        elif 'temperature' in var_name and "geothermal" not in tech.lower():
             # Check if tempearture is in K, if so convert to C
             if np.median(var_array) > 200.00:
                 var_array -= 273.15

--- a/rex/sam_resource.py
+++ b/rex/sam_resource.py
@@ -96,7 +96,7 @@ class SAMResource:
 
     # valid data ranges for solar water heater
     GEOTHERMAL_DATA_RANGES = {'temperature': (-200, 1000),
-                              'potential_MW': (0, 10000)}
+                              'potential_MW': (0, 1_000_000)}
 
     # Data range mapping by SAM tech string
     DATA_RANGES = {'windpower': WIND_DATA_RANGES,

--- a/rex/sam_resource.py
+++ b/rex/sam_resource.py
@@ -149,6 +149,7 @@ class SAMResource:
         if means:
             self._mean_arrays = {}
 
+        # pylint: disable=C0201
         if tech.lower() in self.DATA_RANGES.keys():
             self._tech = tech.lower()
         else:
@@ -667,6 +668,7 @@ class SAMResource:
             raise ResourceRuntimeError(msg)
         else:
             for var in self.var_list:
+                # pylint: disable=C0201
                 if var not in self._res_arrays.keys():
                     msg = '{} has not been set!'.format(var)
                     logger.error(msg)

--- a/rex/version.py
+++ b/rex/version.py
@@ -1,3 +1,3 @@
 """rex Version number"""
 
-__version__ = "0.2.76"
+__version__ = "0.2.77"

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -395,7 +395,7 @@ def check_interp(res_cls, var, h):
     ds_name = '{}_{}m'.format(var, h)
     ds_value = res_cls[ds_name, 0, 0]
 
-    (h1, h2), _ = res_cls.get_nearest_h(h, res_cls.heights[var])
+    (h1, h2), _ = res_cls._get_nearest_val(h, res_cls.heights[var])
 
     ds_name = '{}_{}m'.format(var, h1)
     h1_value = res_cls[ds_name, 0, 0]
@@ -676,7 +676,7 @@ def test_missing_dset_for_heights():
 
         with pytest.raises(ResourceKeyError) as excinfo:
             with WindResource(res_fp) as res:
-                __ = res._get_ds_height('temperature', (0, 0))
+                __ = res._get_ds_interpolated('temperature', (0, 0))
 
     expected_str = "Missing height info for dataset 'temperature'"
     assert expected_str in str(excinfo.value)

--- a/tests/test_resource_geothermal.py
+++ b/tests/test_resource_geothermal.py
@@ -1,0 +1,151 @@
+# -*- coding: utf-8 -*-
+"""
+pytests for Geothermal resource handlers
+"""
+import numpy as np
+import os
+import pytest
+import tempfile
+
+from rex import TESTDATADIR, Resource, Outputs
+from rex.renewable_resource import GeothermalResource
+from rex.utilities.exceptions import ExtrapolationWarning, ResourceWarning
+
+
+SAMPLE_ATTRS = {'units': 'Celsius'}
+
+@pytest.fixture
+def sample_meta():
+    """Sample 10-point meta file. """
+    sample_res_file = os.path.join(TESTDATADIR, "wtk", "ri_100_wtk_2012.h5")
+    with Resource(sample_res_file) as res:
+        meta = res.meta
+
+    meta = meta.iloc[0:10].copy()
+    return meta[['latitude', 'longitude', 'country', 'state', 'county',
+                 'timezone', 'elevation']]
+
+
+
+def test_no_depth(sample_meta):
+    """Test extracting data from file with no depth info."""
+
+    with tempfile.TemporaryDirectory() as td:
+        fp = os.path.join(td, 'outputs.h5')
+
+        Outputs.init_h5(fp, ["temperature", "potential_MW"],
+                        shapes={"temperature": (10,), "potential_MW": (10,)},
+                        attrs={"temperature": SAMPLE_ATTRS,
+                               "potential_MW": SAMPLE_ATTRS},
+                        chunks={"temperature": (10,), "potential_MW": (10,)},
+                        dtypes={"temperature": np.float32,
+                                "potential_MW": np.float32},
+                        meta=sample_meta)
+
+        with Outputs(fp, "a") as out:
+            out["temperature"] = np.random.randint(300, 500, size=10)
+            out["potential_MW"] = np.random.randint(100, 200, size=10)
+
+        with GeothermalResource(fp) as res:
+            assert "potential_MW" in res.dsets
+            assert "temperature" in res.dsets
+            temps = res['temperature']
+            assert np.all(temps >= 300)
+            assert np.all(temps <= 500)
+
+            with pytest.warns(ResourceWarning) as record:
+                temps_3km = res['temperature_3000m']
+            warn_msg = record[0].message.args[0]
+            expected_message = ("No depth info available for "
+                                "'temperature_3000m', returning single "
+                                "'temperature' value for requested depth "
+                                "3000m")
+            assert warn_msg == expected_message
+            assert np.allclose(temps, temps_3km)
+
+            potential = res['potential_MW']
+            assert np.all(potential >= 100)
+            assert np.all(potential <= 200)
+
+            with pytest.warns(ResourceWarning) as record:
+                potential_3km = res['potential_MW_3000m']
+            warn_msg = record[0].message.args[0]
+            expected_message = ("No depth info available for "
+                                "'potential_MW_3000m', returning single "
+                                "'potential_MW' value for requested depth "
+                                "3000m")
+            assert warn_msg == expected_message
+            assert np.allclose(potential, potential_3km)
+
+
+def test_single_depth(sample_meta):
+    """Test extracting data from file with a single depth."""
+
+    with tempfile.TemporaryDirectory() as td:
+        fp = os.path.join(td, 'outputs.h5')
+
+        Outputs.init_h5(fp, ["temperature_3500m"],
+                        shapes={"temperature_3500m": (10,)},
+                        attrs={"temperature_3500m": SAMPLE_ATTRS},
+                        chunks={"temperature_3500m": (10,)},
+                        dtypes={"temperature_3500m": np.float32},
+                        meta=sample_meta)
+
+        with Outputs(fp, "a") as out:
+            out["temperature_3500m"] = np.random.randint(300, 500, size=10)
+
+        with GeothermalResource(fp) as res:
+            assert "temperature_3500m" in res.dsets
+            temps = res['temperature_3500m']
+            assert np.all(temps >= 300)
+            assert np.all(temps <= 500)
+
+            with pytest.warns(ResourceWarning) as record:
+                temps_3km = res['temperature_3000m']
+            warn_msg = record[0].message.args[0]
+            assert "Only one depth available" in warn_msg
+            assert np.allclose(temps, temps_3km)
+
+
+def test_interpolation_and_extrapolation():
+    """Test interpolation and extrapolation of data. """
+    fp = os.path.join(TESTDATADIR, "geo", "template_geo_data.h5")
+    with GeothermalResource(fp) as res:
+        assert "temperature_3500m" in res.dsets
+        assert "temperature_4500m" in res.dsets
+        temps_3500m = res['temperature_3500m']
+        temps_4500m = res['temperature_4500m']
+        assert not np.allclose(temps_3500m, temps_4500m)
+
+        temps_4000m = res['temperature_4000m']
+        expected_temps = (temps_4500m - temps_3500m) / 2 + temps_3500m
+        assert np.allclose(temps_4000m, expected_temps)
+
+
+        with pytest.warns(ExtrapolationWarning) as record:
+            temps_5000m = res['temperature_5000m']
+        warn_msg = record[0].message.args[0]
+        assert "5000 is outside the depth range (3500, 4500)" in warn_msg
+
+        expected_temps = (temps_4500m - temps_3500m) / 2 + temps_4500m
+        assert np.allclose(temps_5000m, expected_temps)
+
+
+def execute_pytest(capture='all', flags='-rapP'):
+    """Execute module as pytest with detailed summary report.
+
+    Parameters
+    ----------
+    capture : str
+        Log or stdout/stderr capture option. ex: log (only logger),
+        all (includes stdout/stderr)
+    flags : str
+        Which tests to show logs and results for.
+    """
+
+    fname = os.path.basename(__file__)
+    pytest.main(['-q', '--show-capture={}'.format(capture), fname, flags])
+
+
+if __name__ == '__main__':
+    execute_pytest()

--- a/tests/test_resource_geothermal.py
+++ b/tests/test_resource_geothermal.py
@@ -131,7 +131,8 @@ def test_interpolation_extrapolation_and_preload(sample_meta):
                                 "temperature_4500m": (10,),
                                 "potential_MW": (10,)},
                         dtypes={"temperature_3500m": np.float32,
-                                "temperature_4500m": np.float32, "potential_MW": np.float32},
+                                "temperature_4500m": np.float32,
+                                "potential_MW": np.float32},
                         meta=sample_meta)
 
         with Outputs(fp, "a") as out:

--- a/tests/test_resource_geothermal.py
+++ b/tests/test_resource_geothermal.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# pylint: disable=no-member
 """
 pytests for Geothermal resource handlers
 """
@@ -142,26 +143,42 @@ def test_interpolation_and_extrapolation():
                 == res.get_dset_properties("temperature_3100m"))
 
 
+def test_parse_name():
+    """Test the `_parse_name` function. """
+    func = GeothermalResource._parse_name
+
+    name, val = func("temp")
+    assert name == "temp"
+    assert val is None
+
+    name, val = func("temp_1m")
+    assert name == "temp"
+    assert val  == 1
+
+    name, val = func("temp_3.5m")
+    assert name == "temp"
+    assert np.isclose(val, 3.5)
+
+
+
 def test_get_nearest_val():
     """Test the `_get_nearest_val` function. """
     sample_depths = [500, 1000, 3000, 100]
-    nearest, extrapolate = GeothermalResource._get_nearest_val(0,
-                                                               sample_depths)
+    func = GeothermalResource._get_nearest_val
+
+    nearest, extrapolate = func(0, sample_depths)
     assert extrapolate
     assert nearest == [100, 500]
 
-    nearest, extrapolate = GeothermalResource._get_nearest_val(700,
-                                                               sample_depths)
+    nearest, extrapolate = func(700, sample_depths)
     assert not extrapolate
     assert nearest == [500, 1000]
 
-    nearest, extrapolate = GeothermalResource._get_nearest_val(2900,
-                                                               sample_depths)
+    nearest, extrapolate = func(2900, sample_depths)
     assert not extrapolate
     assert nearest == [1000, 3000]
 
-    nearest, extrapolate = GeothermalResource._get_nearest_val(5000,
-                                                               sample_depths)
+    nearest, extrapolate = func(5000, sample_depths)
     assert extrapolate
     assert nearest == [1000, 3000]
 

--- a/tests/test_resource_geothermal.py
+++ b/tests/test_resource_geothermal.py
@@ -15,6 +15,7 @@ from rex.utilities.exceptions import ExtrapolationWarning, ResourceWarning
 
 SAMPLE_ATTRS = {'units': 'Celsius'}
 
+
 @pytest.fixture
 def sample_meta():
     """Sample 10-point meta file. """
@@ -25,7 +26,6 @@ def sample_meta():
     meta = meta.iloc[0:10].copy()
     return meta[['latitude', 'longitude', 'country', 'state', 'county',
                  'timezone', 'elevation']]
-
 
 
 def test_no_depth(sample_meta):
@@ -126,7 +126,6 @@ def test_interpolation_and_extrapolation():
         expected_temps = (temps_4500m - temps_3500m) / 2 + temps_3500m
         assert np.allclose(temps_4000m, expected_temps)
 
-
         with pytest.warns(ExtrapolationWarning) as record:
             temps_5000m = res['temperature_5000m']
         warn_msg = record[0].message.args[0]
@@ -153,12 +152,11 @@ def test_parse_name():
 
     name, val = func("temp_1m")
     assert name == "temp"
-    assert val  == 1
+    assert val == 1
 
     name, val = func("temp_3.5m")
     assert name == "temp"
     assert np.isclose(val, 3.5)
-
 
 
 def test_get_nearest_val():

--- a/tests/test_resource_geothermal.py
+++ b/tests/test_resource_geothermal.py
@@ -134,7 +134,6 @@ def test_interpolation_and_extrapolation():
         expected_temps = (temps_4500m - temps_3500m) / 2 + temps_4500m
         assert np.allclose(temps_5000m, expected_temps)
 
-        assert not res.depths['potential_MW']
         assert all(d in res.depths['temperature'] for d in [3500, 4500])
         assert (res.get_attrs("temperature_3000m")
                 == res.get_attrs("temperature_3100m"))

--- a/tests/test_sam_resource.py
+++ b/tests/test_sam_resource.py
@@ -8,7 +8,8 @@ import pandas as pd
 from pandas.testing import assert_series_equal
 import pytest
 
-from rex.renewable_resource import WindResource, NSRDB, WaveResource
+from rex.renewable_resource import (WindResource, NSRDB, WaveResource,
+                                    GeothermalResource)
 from rex.sam_resource import SAMResource
 from rex.utilities.exceptions import ResourceRuntimeError
 from rex.utilities.utilities import roll_timeseries
@@ -337,6 +338,33 @@ def test_wave():
                                                   np.arange(100))
             test = res[var].values
             assert np.allclose(truth, test)
+
+
+def test_preload_sam_geothermal():
+    """Test the preload_SAM method for geothermal data. """
+
+    h5 = os.path.join(TESTDATADIR, 'geo/template_geo_data.h5')
+    sites = [0, 5, 3]
+    depths = 4000
+
+    res = GeothermalResource.preload_SAM(h5, sites, depths)
+
+    with GeothermalResource(h5) as f:
+        for var in res.var_list:
+            res_var_name = "{}_4000m".format(var)
+            assert np.allclose(res[var].values, f[res_var_name, :, sites])
+
+
+    depths = [4500, 3500, 3000]
+    res = GeothermalResource.preload_SAM(h5, sites, depths)
+
+    with GeothermalResource(h5) as f:
+        for var in res.var_list:
+            for depth, site in zip(depths, sites):
+                res_var_name = "{}_{}m".format(var, depth)
+                test = res[var][site].values
+                truth = f[res_var_name, :, site]
+                assert np.allclose(test, truth)
 
 
 def execute_pytest(capture='all', flags='-rapP'):

--- a/tests/test_sam_resource.py
+++ b/tests/test_sam_resource.py
@@ -354,7 +354,6 @@ def test_preload_sam_geothermal():
             res_var_name = "{}_4000m".format(var)
             assert np.allclose(res[var].values, f[res_var_name, :, sites])
 
-
     depths = [4500, 3500, 3000]
     res = GeothermalResource.preload_SAM(h5, sites, depths)
 

--- a/tests/test_sam_resource.py
+++ b/tests/test_sam_resource.py
@@ -185,6 +185,9 @@ def test_preload_sam_hh():
 
     SAM_res = WindResource.preload_SAM(h5, sites, hub_heights)
 
+    assert SAM_res.h == 80
+    assert SAM_res.d is None
+
     with WindResource(h5) as wind:
         p = wind['pressure_100m'] * 9.86923e-6
         t = wind['temperature_100m']

--- a/tests/test_sam_resource.py
+++ b/tests/test_sam_resource.py
@@ -340,32 +340,6 @@ def test_wave():
             assert np.allclose(truth, test)
 
 
-def test_preload_sam_geothermal():
-    """Test the preload_SAM method for geothermal data. """
-
-    h5 = os.path.join(TESTDATADIR, 'geo/template_geo_data.h5')
-    sites = [0, 5, 3]
-    depths = 4000
-
-    res = GeothermalResource.preload_SAM(h5, sites, depths)
-
-    with GeothermalResource(h5) as f:
-        for var in res.var_list:
-            res_var_name = "{}_4000m".format(var)
-            assert np.allclose(res[var].values, f[res_var_name, :, sites])
-
-    depths = [4500, 3500, 3000]
-    res = GeothermalResource.preload_SAM(h5, sites, depths)
-
-    with GeothermalResource(h5) as f:
-        for var in res.var_list:
-            for depth, site in zip(depths, sites):
-                res_var_name = "{}_{}m".format(var, depth)
-                test = res[var][site].values
-                truth = f[res_var_name, :, site]
-                assert np.allclose(test, truth)
-
-
 def execute_pytest(capture='all', flags='-rapP'):
     """Execute module as pytest with detailed summary report.
 


### PR DESCRIPTION
rex Support for Geothermal Resource Data
==
The new functionality added in this PR can handle datasets like the SMU Temperature-at-Depth Dataset, the USGS Heat Flow datasets, and even point-like datasets such as Identified or Unidentified Hydrothermal locations. This functionality is compliant with the reV standard format and is ready to be fully integrated into reV.


Details
--

Added `GeothermalResource` class. This class behaves like the `WindResource` class, with `depth` as the analogous variable to `hub_height`. Indeed, both are the children of a new `AbstractInterpolatedResource` class, which provides the functionality it was named after. 

Added new test file to cover test cases for Geothermal resources. 