### PR TITLE
Fix Bug in `wind-rose` CLI

### DIFF
--- a/.github/workflows/pr_rev_tests.yml
+++ b/.github/workflows/pr_rev_tests.yml
@@ -6,8 +6,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout rex
+      - name: checkout rex
         uses: actions/checkout@v3
+        with:
+          path: rex
       - name: checkout reV
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/pr_rev_tests.yml
+++ b/.github/workflows/pr_rev_tests.yml
@@ -6,33 +6,29 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - name: checkout rex
-      uses: actions/checkout@v2
-      with:
-        ref: ${{ github.event.pull_request.head.ref }}
-        fetch-depth: 1
-        path: rex
-    - name: checkout reV
-      uses: actions/checkout@v2
-      with:
-        repository: nrel/reV
-        fetch-depth: 1
-        path: reV
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.9
-    - name: Install rex dependencies
-      working-directory: ./rex
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install .
-    - name: Install reV dependencies
-      working-directory: ./reV
-      run: |
-        python -m pip install .
-    - name: Run reV pytest
-      working-directory: ./reV
-      run: |
-        python -m pip install pytest
-        python -m pytest -v --disable-warnings
+      - name: Checkout rex
+        uses: actions/checkout@v3
+      - name: checkout reV
+        uses: actions/checkout@v3
+        with:
+          repository: nrel/reV
+          fetch-depth: 1
+          path: reV
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Install rex dependencies
+        working-directory: ./rex
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install .
+      - name: Install reV dependencies
+        working-directory: ./reV
+        run: |
+          python -m pip install .
+      - name: Run reV pytest
+        working-directory: ./reV
+        run: |
+          python -m pip install pytest
+          python -m pytest -v --disable-warnings

--- a/.github/workflows/pr_revx_tests.yml
+++ b/.github/workflows/pr_revx_tests.yml
@@ -6,40 +6,36 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - name: checkout rex
-      uses: actions/checkout@v2
-      with:
-        ref: ${{ github.event.pull_request.head.ref }}
-        fetch-depth: 1
-        path: rex
-    - name: checkout reVX
-      uses: actions/checkout@v2
-      with:
-        repository: nrel/reVX
-        fetch-depth: 1
-        path: reVX
-    - name: Set up Python
-      uses: conda-incubator/setup-miniconda@v2
-      with:
-        auto-update-conda: true
-        python-version: 3.9
-    - name: Install rex dependencies
-      working-directory: ./rex
-      shell: bash -l {0}
-      run: |
-        conda install pip pandas
-        pip install -e .
-    - name: Install reVX dependencies
-      working-directory: ./reVX
-      shell: bash -l {0}
-      run: |
-        conda install rtree pytest
-        pip install geopandas
-        pip install --upgrade --force-reinstall shapely~=1.8
-        pip install -e .
-        pip install HOPP
-    - name: Run reVX pytest
-      working-directory: ./reVX
-      shell: bash -l {0}
-      run: |
-        pytest -v --disable-warnings
+      - name: Checkout rex
+        uses: actions/checkout@v3
+      - name: checkout reVX
+        uses: actions/checkout@v3
+        with:
+          repository: nrel/reVX
+          fetch-depth: 1
+          path: reVX
+      - name: Set up Python
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          auto-update-conda: true
+          python-version: 3.9
+      - name: Install rex dependencies
+        working-directory: ./rex
+        shell: bash -l {0}
+        run: |
+          conda install pip pandas
+          pip install -e .
+      - name: Install reVX dependencies
+        working-directory: ./reVX
+        shell: bash -l {0}
+        run: |
+          conda install rtree pytest
+          pip install geopandas
+          pip install --upgrade --force-reinstall shapely~=1.8
+          pip install -e .
+          pip install HOPP
+      - name: Run reVX pytest
+        working-directory: ./reVX
+        shell: bash -l {0}
+        run: |
+          pytest -v --disable-warnings

--- a/.github/workflows/pr_revx_tests.yml
+++ b/.github/workflows/pr_revx_tests.yml
@@ -6,10 +6,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout rex
+      - name: checkout rex
         uses: actions/checkout@v3
+        with:
+          path: rex
       - name: checkout reVX
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2
         with:
           repository: nrel/reVX
           fetch-depth: 1

--- a/.github/workflows/pull_request_tests.yml
+++ b/.github/workflows/pull_request_tests.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.10']
+        python-version: ["3.10"]
         include:
           - os: ubuntu-latest
             python-version: 3.9
@@ -17,31 +17,29 @@ jobs:
             python-version: 3.8
 
     steps:
-    - uses: actions/checkout@v2
-      with:
-        ref: ${{ github.event.pull_request.head.ref }}
-        fetch-depth: 1
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        pip install --upgrade pip
-        pip install pytest
-        pip install pytest-cov
-        pip install -e .
-    - name: Run pytest and Generate coverage report
-      run: |
-        cd tests
-        pytest -v --disable-warnings --cov=./ --cov-report=xml:coverage.xml
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        file: ./coverage.xml
-        flags: unittests
-        env_vars: OS,PYTHON
-        name: codecov-umbrella
-        fail_ci_if_error: false
-        verbose: true
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip
+          pip install pytest
+          pip install pytest-cov
+          pip install -e .
+      - name: Run pytest and Generate coverage report
+        run: |
+          cd tests
+          pytest -v --disable-warnings --cov=./ --cov-report=xml:coverage.xml
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: ./coverage.xml
+          flags: unittests
+          env_vars: OS,PYTHON
+          name: codecov-umbrella
+          fail_ci_if_error: false
+          verbose: true

--- a/setup.py
+++ b/setup.py
@@ -65,8 +65,7 @@ setup(
             "US-wave=rex.resource_extraction.US_wave_cli:main",
             "rechunk=rex.rechunk_h5.rechunk_cli:main",
             "combine-h5=rex.rechunk_h5.combine_h5_cli:main",
-            "temporal-stats=rex.temporal_stats.temporal_stats_cli:main",
-            "wind-rose=rex.jpd.wind_rose_cli:main"
+            "temporal-stats=rex.temporal_stats.temporal_stats_cli:main"
         ],
     },
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,8 @@ setup(
             "US-wave=rex.resource_extraction.US_wave_cli:main",
             "rechunk=rex.rechunk_h5.rechunk_cli:main",
             "combine-h5=rex.rechunk_h5.combine_h5_cli:main",
-            "temporal-stats=rex.temporal_stats.temporal_stats_cli:main"
+            "temporal-stats=rex.temporal_stats.temporal_stats_cli:main",
+            "wind-rose=rex.joint_pd.wind_rose_cli:main"
         ],
     },
     include_package_data=True,


### PR DESCRIPTION
`setup.py` incorrectly specifies the cli path of wind-rose.

Calling `wind-rose --help` will fail currently.

![image](https://github.com/NREL/rex/assets/13438942/549f10c0-1522-4004-bc01-24f56f53e4bd)


Setting the cli path from `wind-rose=rex.jpd.wind_rose_cli:main` to  `wind-rose=rex.joint_pd.wind_rose_cli:main` (and reinstalling the package) fixes this:
![image](https://github.com/NREL/rex/assets/13438942/919f207a-abdf-4942-927c-8224e5516d75)
