### PR TITLE
Make hsds optional dependency

### DIFF
--- a/.github/workflows/h5pyd_tests.yml
+++ b/.github/workflows/h5pyd_tests.yml
@@ -36,7 +36,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install pytest
           pip install pytest-cov
-          pip install -e .
+          pip install -e .[hsds]
 
       - name: Start HSDS and run tests
         shell: bash

--- a/examples/HSDS/README.rst
+++ b/examples/HSDS/README.rst
@@ -43,11 +43,11 @@ Setting up an HSDS server on an EC2 instance or your local machine isn't too har
 
 Make sure you have python 3.x (we recommend 3.10), pip, and git installed. We find it easiest to manage your HSDS environment by installing `miniconda <https://docs.conda.io/en/latest/miniconda.html>`_ and creating a clean HSDS environment. Once you have that setup, follow these instructions:
 
-#. In your shell, install nrel-rex >= v0.2.86 using pip (this should also install HSDS and h5pyd).
+#. In your shell, install nrel-rex >= v0.2.88 using pip, making sure to include the optional HSDS dependency:
 
     .. code-block:: bash
 
-      pip install "nrel-rex>=0.2.86"
+      pip install "nrel-rex[hsds]>=0.2.88"
 
 #. Set your environment variables (if using windows, use ``set`` instead of ``export``) (this has to be done every time you login to a shell unless you set these in your ``.bashrc``):
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 click>=7.0
 h5py>=2.10.0,!=3.0.0
 h5pyd>=0.18.0
-hsds>=0.8.4
 numpy>=1.16
 pandas>=2.0
 psutil>=5.6

--- a/rex/version.py
+++ b/rex/version.py
@@ -1,3 +1,3 @@
 """rex Version number"""
 
-__version__ = "0.2.87"
+__version__ = "0.2.88"

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ with open("requirements.txt") as f:
     install_requires = f.readlines()
 
 test_requires = ["pytest>=5.2", ]
+dev_requires = ["flake8", "pre-commit", "pylint", "hsds>=0.8.4"]
 description = ("National Renewable Energy Laboratory's (NREL's) REsource "
                "eXtraction tool: rex")
 
@@ -87,7 +88,8 @@ setup(
     install_requires=install_requires,
     extras_require={
         "test": test_requires,
-        "dev": test_requires + ["flake8", "pre-commit", "pylint"],
+        "dev": test_requires + dev_requires,
+        "hsds": ["hsds>=0.8.4"]
     },
     cmdclass={"develop": PostDevelopCommand},
 )


### PR DESCRIPTION
HSDS was causing some installation conflicts, particularly with https://github.com/NREL/cloud_fs

This PR moves HSDS to be an optional dependency, which still gives access to all HSDS functionality, but without requiring it to be installed with every rex distribution.