### PR TITLE
Update regridder.py

### DIFF
--- a/rex/utilities/regridder.py
+++ b/rex/utilities/regridder.py
@@ -59,8 +59,9 @@ class _InterpolationMixin:
         msg = "Input data must be 2D (spatial, temporal)"
         assert len(data.shape) == 2, msg
 
-        if hasattr(data, 'vindex'):  # data is Dask array
-            vals = data.vindex[self.indices]
+        if hasattr(data, "compute"):  # data is Dask array
+            shape = (len(self.indices), self.k_neighbors, data.shape[-1])
+            vals = data[np.concatenate(self.indices)].reshape(shape)
         else:
             vals = data[self.indices]
 


### PR DESCRIPTION
Regridding high res GWA data to the wtk grid shows that using vindex is ~2x slower than using np.concatenate and reshaping. 

https://docs.dask.org/en/latest/generated/dask.array.Array.vindex.html mentions fewer optimizations and potential for slow down. Since we dont _need_ fancy indexing here we should revert.