### PR TITLE
Wildcard support for list input to `MultiTimeResource`

### DIFF
--- a/rex/multi_time_resource.py
+++ b/rex/multi_time_resource.py
@@ -3,8 +3,9 @@
 Classes to handle resource data stored over multiple files
 """
 import os
-from fnmatch import fnmatch
 from glob import glob
+from itertools import chain
+from fnmatch import fnmatch
 
 import numpy as np
 import pandas as pd
@@ -33,8 +34,9 @@ class MultiTimeH5:
         h5_path : str | list
             Unix shell style pattern path with * wildcards to multi-file
             resource file sets. Files must have the same coordinates
-            but can have different datasets or time indexes. Can also be an
-            explicit list of multi time files.
+            but can have different datasets or time indexes. Can also be
+            an explicit list of multi time files, which themselves can
+            contain * wildcards.
         res_cls : obj
             Resource class to use to open and access resource data
         hsds : bool
@@ -260,8 +262,9 @@ class MultiTimeH5:
         h5_path : str | list
             Unix shell style pattern path with * wildcards to multi-file
             resource file sets. Files must have the same coordinates
-            but can have different datasets or time indexes. Can also be an
-            explicit list of multi time files.
+            but can have different datasets or time indexes. Can also be
+            an explicit list of multi time files, which themselves can
+            contain * wildcards.
         hsds : bool
             Boolean flag to use h5pyd to handle .h5 'files' hosted on AWS
             behind HSDS
@@ -279,10 +282,9 @@ class MultiTimeH5:
             file_paths = cls._get_hsds_file_paths(h5_path,
                                                   hsds_kwargs=hsds_kwargs)
         elif isinstance(h5_path, (list, tuple)):
-            for fp in h5_path:
-                msg = 'Does not exist: {}'.format(fp)
-                assert os.path.exists(fp), msg
-            file_paths = h5_path
+            file_paths = list(chain.from_iterable(glob(fp) for fp in h5_path))
+            for fp in file_paths:
+                assert os.path.exists(fp), 'Does not exist: {}'.format(fp)
         elif os.path.isdir(h5_path):
             msg = ('h5_path must be a unix shell style pattern with '
                    'wildcard * in order to find files, but received '
@@ -494,8 +496,9 @@ class MultiTimeResource:
         h5_path : str | list
             Unix shell style pattern path with * wildcards to multi-file
             resource file sets. Files must have the same coordinates
-            but can have different datasets or time indexes. Can also be an
-            explicit list of multi time files.
+            but can have different datasets or time indexes. Can also be
+            an explicit list of multi time files, which themselves can
+            contain * wildcards.
         unscale : bool
             Boolean flag to automatically unscale variables on extraction
         str_decode : bool
@@ -865,8 +868,9 @@ class MultiTimeSolarResource:
         h5_path : str | list
             Unix shell style pattern path with * wildcards to multi-file
             resource file sets. Files must have the same coordinates
-            but can have different datasets or time indexes. Can also be an
-            explicit list of multi time files.
+            but can have different datasets or time indexes. Can also be
+            an explicit list of multi time files, which themselves can
+            contain * wildcards.
         unscale : bool
             Boolean flag to automatically unscale variables on extraction
         str_decode : bool
@@ -900,8 +904,9 @@ class MultiTimeNSRDB(MultiTimeResource):
         h5_path : str | list
             Unix shell style pattern path with * wildcards to multi-file
             resource file sets. Files must have the same coordinates
-            but can have different datasets or time indexes. Can also be an
-            explicit list of multi time files.
+            but can have different datasets or time indexes. Can also be
+            an explicit list of multi time files, which themselves can
+            contain * wildcards.
         unscale : bool
             Boolean flag to automatically unscale variables on extraction
         str_decode : bool
@@ -935,8 +940,9 @@ class MultiTimeWindResource(MultiTimeResource):
         h5_path : str | list
             Unix shell style pattern path with * wildcards to multi-file
             resource file sets. Files must have the same coordinates
-            but can have different datasets or time indexes. Can also be an
-            explicit list of multi time files.
+            but can have different datasets or time indexes. Can also be
+            an explicit list of multi time files, which themselves can
+            contain * wildcards.
         unscale : bool
             Boolean flag to automatically unscale variables on extraction
         str_decode : bool
@@ -968,8 +974,9 @@ class MultiTimeWaveResource(MultiTimeResource):
         h5_path : str | list
             Unix shell style pattern path with * wildcards to multi-file
             resource file sets. Files must have the same coordinates
-            but can have different datasets or time indexes. Can also be an
-            explicit list of multi time files.
+            but can have different datasets or time indexes. Can also be
+            an explicit list of multi time files, which themselves can
+            contain * wildcards.
         unscale : bool
             Boolean flag to automatically unscale variables on extraction
         str_decode : bool

--- a/rex/multi_year_resource.py
+++ b/rex/multi_year_resource.py
@@ -411,10 +411,12 @@ class MultiYearResource(MultiTimeResource):
         """
         Parameters
         ----------
-        h5_path : str
+        h5_path : str | list
             Unix shell style pattern path with * wildcards to multi-file
             resource file sets. Files must have the same coordinates
-            but can have different datasets or time indexes.
+            but can have different datasets or time indexes. Can also be
+            an explicit list of multi time files, which themselves can
+            contain * wildcards.
         years : list, optional
             List of years to access, by default None
         unscale : bool
@@ -498,10 +500,12 @@ class MultiYearNSRDB(MultiYearResource):
         """
         Parameters
         ----------
-        h5_path : str
+        h5_path : str | list
             Unix shell style pattern path with * wildcards to multi-file
             resource file sets. Files must have the same coordinates
-            but can have different datasets or time indexes.
+            but can have different datasets or time indexes. Can also be
+            an explicit list of multi time files, which themselves can
+            contain * wildcards.
         years : list, optional
             List of years to access, by default None
         unscale : bool
@@ -532,10 +536,12 @@ class MultiYearWindResource(MultiYearResource):
         """
         Parameters
         ----------
-        h5_path : str
+        h5_path : str | list
             Unix shell style pattern path with * wildcards to multi-file
             resource file sets. Files must have the same coordinates
-            but can have different datasets or time indexes.
+            but can have different datasets or time indexes. Can also be
+            an explicit list of multi time files, which themselves can
+            contain * wildcards.
         years : list, optional
             List of years to access, by default None
         unscale : bool
@@ -566,10 +572,12 @@ class MultiYearWaveResource(MultiYearResource):
         """
         Parameters
         ----------
-        h5_path : str
+        h5_path : str | list
             Unix shell style pattern path with * wildcards to multi-file
             resource file sets. Files must have the same coordinates
-            but can have different datasets or time indexes.
+            but can have different datasets or time indexes. Can also be
+            an explicit list of multi time files, which themselves can
+            contain * wildcards.
         years : list, optional
             List of years to access, by default None
         unscale : bool

--- a/rex/version.py
+++ b/rex/version.py
@@ -1,3 +1,3 @@
 """rex Version number"""
 
-__version__ = "0.2.88"
+__version__ = "0.2.89"

--- a/tests/test_multi_time_resource.py
+++ b/tests/test_multi_time_resource.py
@@ -36,6 +36,16 @@ def MultiTimeNSRDB_list_res():
 
 
 @pytest.fixture
+def MultiTimeNSRDB_wildcard_list_res():
+    """
+    Init NSRDB resource handler
+    """
+    files = [os.path.join(TESTDATADIR, 'nsrdb/ri_100_nsrdb_20*.h5')]
+
+    return MultiTimeNSRDB(files)
+
+
+@pytest.fixture
 def MultiTimeWind_res():
     """
     Init WindResource resource handler
@@ -256,6 +266,49 @@ class TestMultiTimeList:
         check_attrs(MultiTimeNSRDB_list_res, ds_name)
         check_properties(MultiTimeNSRDB_list_res, ds_name)
         MultiTimeNSRDB_list_res.close()
+
+
+class TestMultiTimeWildcardList:
+    """
+    Test multi time resource handler from list of files with wildcards
+    """
+    @staticmethod
+    def test_res(MultiTimeNSRDB_wildcard_list_res):
+        """
+        test NSRDB class calls
+        """
+        check_res(MultiTimeNSRDB_wildcard_list_res)
+        assert len(MultiTimeNSRDB_wildcard_list_res.h5.files) >= 2
+        MultiTimeNSRDB_wildcard_list_res.close()
+
+    @staticmethod
+    def test_meta(MultiTimeNSRDB_wildcard_list_res):
+        """
+        test extraction of NSRDB meta data
+        """
+        check_meta(MultiTimeNSRDB_wildcard_list_res)
+        assert len(MultiTimeNSRDB_wildcard_list_res.h5.files) >= 2
+        MultiTimeNSRDB_wildcard_list_res.close()
+
+    @staticmethod
+    def test_time_index(MultiTimeNSRDB_wildcard_list_res):
+        """
+        test extraction of NSRDB time_index
+        """
+        check_time_index(MultiTimeNSRDB_wildcard_list_res)
+        assert len(MultiTimeNSRDB_wildcard_list_res.h5.files) >= 2
+        MultiTimeNSRDB_wildcard_list_res.close()
+
+    @staticmethod
+    def test_ds(MultiTimeNSRDB_wildcard_list_res, ds_name='dni'):
+        """
+        test extraction of a variable array, attributes, and properties
+        """
+        check_dset(MultiTimeNSRDB_wildcard_list_res, ds_name)
+        check_attrs(MultiTimeNSRDB_wildcard_list_res, ds_name)
+        check_properties(MultiTimeNSRDB_wildcard_list_res, ds_name)
+        assert len(MultiTimeNSRDB_wildcard_list_res.h5.files) >= 2
+        MultiTimeNSRDB_wildcard_list_res.close()
 
 
 class TestMultiTimeWindResource:

--- a/tests/test_multi_time_resource.py
+++ b/tests/test_multi_time_resource.py
@@ -376,6 +376,21 @@ def test_map_hsds_files():
     assert not any(wrong), 'Wrong files: {}'.format(wrong)
 
 
+def test_multi_time_resource_acts_like_resource_single_file():
+    """Test that MultiTimeWindResource nehaves like Resource for one file."""
+
+    path = os.path.join(TESTDATADIR, 'wtk/ri_100_wtk_2012.h5')
+
+    with Resource(path) as res, MultiTimeWindResource([path]) as mt_res:
+        assert set(res.datasets) == set(mt_res.datasets)
+        assert (res.time_index == mt_res.time_index).all()
+        assert res.shape == mt_res.shape
+        for ds in res.datasets:
+            if any(kw in ds for kw in ['meta', 'time']):
+                continue
+            assert np.allclose(res[ds], mt_res[ds])
+
+
 def execute_pytest(capture='all', flags='-rapP'):
     """Execute module as pytest with detailed summary report.
 

--- a/tests/test_multi_time_resource.py
+++ b/tests/test_multi_time_resource.py
@@ -377,7 +377,7 @@ def test_map_hsds_files():
 
 
 def test_multi_time_resource_acts_like_resource_single_file():
-    """Test that MultiTimeWindResource nehaves like Resource for one file."""
+    """Test that MultiTimeWindResource behaves like Resource for one file."""
 
     path = os.path.join(TESTDATADIR, 'wtk/ri_100_wtk_2012.h5')
 


### PR DESCRIPTION
Allow `MultiTimeResource` to accept wildcards in list so you can do something like:

```python
from rex import MultiYearWindResource

files = [
    "/datasets/WIND/conus/v1.0.0/wtk_conus_*.h5",
    "/scratch/ppinchuk/HRRR/HRRR*.h5",
]

with MultiYearWindResource(files) as res:
    print(res.time_index.year.unique())
--------------------------------------------
Index([2007, 2008, 2009, 2010, 2011, 2012, 2013, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023], dtype='int32')
```

Any foreseeable pitfalls here that I may be missing?