### PR TITLE
Correctly extract grouped attrs

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -19,10 +19,11 @@ jobs:
         pip install --upgrade pip
         pip install pytest
         pip install pytest-cov
+        pip install pytest-timeout
+        pip install flaky
         pip install -e .
     - name: Generate coverage report
       run: |
-        pip install pytest-cov
         cd tests
         pytest --disable-warnings --cov=./ --cov-report=xml:coverage.xml
     - name: Upload coverage to Codecov

--- a/.github/workflows/pull_request_tests.yml
+++ b/.github/workflows/pull_request_tests.yml
@@ -29,6 +29,7 @@ jobs:
           pip install pytest
           pip install pytest-cov
           pip install pytest-timeout
+          pip install flaky
           pip install -e .
       - name: Run pytest and Generate coverage report
         run: |

--- a/rex/multi_file_resource.py
+++ b/rex/multi_file_resource.py
@@ -127,7 +127,7 @@ class MultiH5(BaseDatasetIterable):
         shared_dsets = []
         try:
             with h5py.File(h5_path, mode='r') as f:
-                for dset in f:
+                for dset in Resource._get_datasets(f):
                     if dset not in ['meta', 'time_index', 'coordinates']:
                         unique_dsets.append(dset)
                     else:

--- a/rex/rechunk_h5/rechunk_h5.py
+++ b/rex/rechunk_h5/rechunk_h5.py
@@ -44,7 +44,7 @@ def get_dataset_attributes(h5_file, out_json=None, chunk_size=2,
     with h5py.File(h5_file, 'r') as f:
         global_attrs = dict(f.attrs)
 
-        for ds_name in BaseResource._get_datasets(f):
+        for ds_name in f:
             ds = f[ds_name]
             try:
                 arr_size = ds_name in ['meta', 'coordinates', 'time_index']

--- a/rex/rechunk_h5/rechunk_h5.py
+++ b/rex/rechunk_h5/rechunk_h5.py
@@ -44,7 +44,7 @@ def get_dataset_attributes(h5_file, out_json=None, chunk_size=2,
     with h5py.File(h5_file, 'r') as f:
         global_attrs = dict(f.attrs)
 
-        for ds_name in f:
+        for ds_name in BaseResource._get_datasets(f):
             ds = f[ds_name]
             try:
                 arr_size = ds_name in ['meta', 'coordinates', 'time_index']
@@ -88,6 +88,9 @@ def get_dataset_attributes(h5_file, out_json=None, chunk_size=2,
 class RechunkH5:
     """
     Class to create new .h5 file with new chunking
+
+    .. WARNING:: This code does not currently support re-chunking H5
+                 files with grouped datasets.
     """
     # None time-series
     NON_TS_DSETS = ('meta', 'coordinates', 'time_index')

--- a/rex/resource.py
+++ b/rex/resource.py
@@ -924,7 +924,7 @@ class BaseResource(BaseDatasetIterable):
         """
         if self._attrs is None:
             self._attrs = {}
-            for dset in set(self.datasets).intersection(self.h5):
+            for dset in self.datasets:
                 self._attrs[dset] = dict(self.h5[dset].attrs)
 
         return self._attrs

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ class PostDevelopCommand(develop):
 with open("requirements.txt") as f:
     install_requires = f.readlines()
 
-test_requires = ["pytest>=5.2", "pytest-timeout>=2.3.1"]
+test_requires = ["pytest>=5.2", "pytest-timeout>=2.3.1", "flaky>=3.8.1"]
 dev_requires = ["flake8", "pre-commit", "pylint", "hsds>=0.8.4"]
 description = ("National Renewable Energy Laboratory's (NREL's) REsource "
                "eXtraction tool: rex")

--- a/tests/test_bc.py
+++ b/tests/test_bc.py
@@ -4,11 +4,13 @@ pytests for bias correction utilities
 """
 
 import numpy as np
+from flaky import flaky
 
 from rex.temporal_stats.temporal_stats import cdf
 from rex.utilities.bc_utils import QuantileDeltaMapping
 
 
+@flaky(max_runs=3, min_passes=1)
 def test_qdm():
     """Test basic QuantileDeltaMapping functionality with dummy distributions
 


### PR DESCRIPTION
Correctly extract `attrs`, `chunks`, `shapes`, etc. for datasets belonging to a group.
This includes `Resource` and `MultiFileResource`. 

This does **not** include the `RechunkH5` class since it was not built for grouped datasets (added this as a note to the docstring) and would require more careful refactoring. This could be a future endeavor. 

Did not find any other instances of reading datasets using `h5py` directly in `rex`, but it's possible I missed some. Can fix those in the same manner if/when they come up.


Also marked that BC test that keeps failing as flaky for more flexibility.