### PR TITLE
Add suggestions for `xarray .open_mfdataset` parameters

### DIFF
--- a/examples/xarray/README.rst
+++ b/examples/xarray/README.rst
@@ -217,7 +217,16 @@ For more information on using dask with xarray, see `this <https://docs.xarray.d
 Opening Multiple Files
 ^^^^^^^^^^^^^^^^^^^^^^
 
-You can use ``xr.open_mfdataset`` to open multiple NREL data files at once:
+You can use ``xr.open_mfdataset`` to open multiple NREL data files at once.
+
+.. IMPORTANT::
+    By default, ``xarray`` does not assume that the coordinate data (i.e. meta variables)
+    match across files. As a result, it will try to load all coordinates and compare them
+    during the concatenation step. This process involves significant I/O and can drastically
+    increase the runtime of ``xr.open_mfdataset`` calls. Since the underlying assumption in
+    rex-style data is that the meta remains consistent across files, we can tell ``xarray``
+    to skip this validation by passing  ``compat="override"`` and ``coords="minimal"`` to the
+    ``xr.open_mfdataset`` call.
 
 
 .. code-block:: python
@@ -228,7 +237,7 @@ You can use ``xr.open_mfdataset`` to open multiple NREL data files at once:
 
     WTK_FPS = os.path.join(TESTDATADIR, 'wtk', 'ri_100_wtk_20*.h5')
 
-    ds = xr.open_mfdataset(WTK_FPS, engine="rex")
+    ds = xr.open_mfdataset(WTK_FPS, engine="rex", compat="override", coords="minimal")
     ds
 
 .. code-block:: python-console
@@ -405,7 +414,7 @@ so to open multiple files on S3, you have to list them out explicitly:
         "s3://nrel-pds-nsrdb/current/nsrdb_1998.h5",
         "s3://nrel-pds-nsrdb/current/nsrdb_1999.h5",
     ]
-    ds = xr.open_mfdataset(files, engine="rex")
+    ds = xr.open_mfdataset(files, engine="rex", compat="override", coords="minimal")
     ds
 
 .. code-block:: python-console
@@ -450,7 +459,7 @@ accept wildcard inputs:
     import xarray as xr
     from rex import open_mfdataset_hsds
 
-    ds = open_mfdataset_hsds("/nrel/nsrdb/v3/nsrdb_199*.h5")
+    ds = open_mfdataset_hsds("/nrel/nsrdb/v3/nsrdb_199*.h5", compat="override", coords="minimal")
     ds
 
 

--- a/examples/xarray/daily_agg.ipynb
+++ b/examples/xarray/daily_agg.ipynb
@@ -23,7 +23,9 @@
     "\n",
     "- The `memory_limit` argument is the limit *per worker*. If you are memory constrained, try using less workers and setting a lower memory limit and reducing the compute chunk size. Here, we're processing on a large NREL HPC node with 104 cores and 256 GB of memory.\n",
     "\n",
-    "- Setting up the full aggregate dataset lazily and then doing one `.compute()` call tended to break things. Smaller multiple compute calls seem to work better. "
+    "- Setting up the full aggregate dataset lazily and then doing one `.compute()` call tended to break things. Smaller multiple compute calls seem to work better. \n",
+    "\n",
+    "- By default, ``xarray`` does not assume that the coordinate data (i.e. meta variables) match across files. As a result, it library will try to load all coordinates and compare them during the concatenation step. This process involves significant I/O and can drastically increase the runtime of ``xr.open_mfdataset`` calls. To override this behavior, we can pass ``compat=\"override\"`` and ``coords=\"minimal\"`` to the xr.open_mfdataset`` call."
    ]
   },
   {
@@ -637,7 +639,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "0c069232-6e46-4ef3-b34c-efeb623ebf49",
    "metadata": {
     "scrolled": true
@@ -661,7 +663,8 @@
     "fp_base = '/datasets/sup3rcc/conus_{scenario}/v0.2.2_beta/sup3rcc_conus_{scenario}_{group}_{year}.h5'\n",
     "fp_pr = fp_base.replace('v0.2.2_beta', 'v0.2.2_beta/daily')\n",
     "\n",
-    "kwargs = dict(engine=\"rex\", chunks={'time': 8784, 'gid': 50000})\n",
+    "kwargs = dict(engine=\"rex\", chunks={'time': 8784, 'gid': 50000},\n",
+    "              compat=\"override\", coords=\"minimal\")\n",
     "xds_trh = xr.open_mfdataset(fp_base.format(scenario=scenario, group='trh', year=year), **kwargs)\n",
     "xds_wind = xr.open_mfdataset(fp_base.format(scenario=scenario, group='wind', year=year), **kwargs)\n",
     "xds_pr = xr.open_mfdataset(fp_pr.format(scenario=scenario, group='pr', year=year), **kwargs)"

--- a/examples/xarray/daily_agg.ipynb
+++ b/examples/xarray/daily_agg.ipynb
@@ -25,7 +25,7 @@
     "\n",
     "- Setting up the full aggregate dataset lazily and then doing one `.compute()` call tended to break things. Smaller multiple compute calls seem to work better. \n",
     "\n",
-    "- By default, ``xarray`` does not assume that the coordinate data (i.e. meta variables) match across files. As a result, it library will try to load all coordinates and compare them during the concatenation step. This process involves significant I/O and can drastically increase the runtime of ``xr.open_mfdataset`` calls. To override this behavior, we can pass ``compat=\"override\"`` and ``coords=\"minimal\"`` to the xr.open_mfdataset`` call."
+    "- By default, ``xarray`` does not assume that the coordinate data (i.e. meta variables) match across files. As a result, it library will try to load all coordinates and compare them during the concatenation step. This process involves significant I/O and can drastically increase the runtime of ``xr.open_mfdataset`` calls. To override this behavior, we can pass ``compat=\"override\"`` and ``coords=\"minimal\"`` to the ``xr.open_mfdataset`` call."
    ]
   },
   {

--- a/examples/xarray/daily_agg.ipynb
+++ b/examples/xarray/daily_agg.ipynb
@@ -25,20 +25,17 @@
     "\n",
     "- Setting up the full aggregate dataset lazily and then doing one `.compute()` call tended to break things. Smaller multiple compute calls seem to work better. \n",
     "\n",
-    "- By default, ``xarray`` does not assume that the coordinate data (i.e. meta variables) match across files. As a result, it library will try to load all coordinates and compare them during the concatenation step. This process involves significant I/O and can drastically increase the runtime of ``xr.open_mfdataset`` calls. To override this behavior, we can pass ``compat=\"override\"`` and ``coords=\"minimal\"`` to the ``xr.open_mfdataset`` call."
+    "- If you are running on a network file system (NFS) such as on an HPC, try setting the ``local_directory`` parameter of the ``Client`` instance to point to a local scratch to avoid the overhead of network calls for each of the workers."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "171a1a77-a6e2-4280-8a6b-fc8a286b0895",
    "metadata": {},
    "outputs": [],
    "source": [
-    "import glob\n",
     "import xarray as xr\n",
-    "from rex import Resource\n",
-    "import numpy as np\n",
     "import pandas as pd\n",
     "from dask.distributed import Client"
    ]
@@ -663,16 +660,15 @@
     "fp_base = '/datasets/sup3rcc/conus_{scenario}/v0.2.2_beta/sup3rcc_conus_{scenario}_{group}_{year}.h5'\n",
     "fp_pr = fp_base.replace('v0.2.2_beta', 'v0.2.2_beta/daily')\n",
     "\n",
-    "kwargs = dict(engine=\"rex\", chunks={'time': 8784, 'gid': 50000},\n",
-    "              compat=\"override\", coords=\"minimal\")\n",
-    "xds_trh = xr.open_mfdataset(fp_base.format(scenario=scenario, group='trh', year=year), **kwargs)\n",
-    "xds_wind = xr.open_mfdataset(fp_base.format(scenario=scenario, group='wind', year=year), **kwargs)\n",
-    "xds_pr = xr.open_mfdataset(fp_pr.format(scenario=scenario, group='pr', year=year), **kwargs)"
+    "kwargs = dict(engine=\"rex\", chunks={'time': 8784, 'gid': 50000})\n",
+    "xds_trh = xr.open_dataset(fp_base.format(scenario=scenario, group='trh', year=year), **kwargs)\n",
+    "xds_wind = xr.open_dataset(fp_base.format(scenario=scenario, group='wind', year=year), **kwargs)\n",
+    "xds_pr = xr.open_dataset(fp_pr.format(scenario=scenario, group='pr', year=year), **kwargs)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "d02dc16a-7727-47ee-b265-a6984181bf9e",
    "metadata": {},
    "outputs": [
@@ -687,13 +683,13 @@
    ],
    "source": [
     "%%time\n",
-    "da = xds_trh['temperature_2m'].groupby(\"time.date\").max(\"time\")\n",
+    "da = xds_trh['temperature_2m'].groupby(\"time.date\").max(dim=\"time\")\n",
     "ds_out = da.compute().to_dataset()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "3710d159-370f-48de-8c7b-0c3b30082504",
    "metadata": {},
    "outputs": [
@@ -708,13 +704,13 @@
    ],
    "source": [
     "%%time\n",
-    "da = xds_trh['relativehumidity_2m'].groupby(\"time.date\").min(\"time\")\n",
+    "da = xds_trh['relativehumidity_2m'].groupby(\"time.date\").min(dim=\"time\")\n",
     "ds_out['relativehumidity_2m'] = da.compute()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "0436ece4-c14a-4ca7-926e-6f5dc280ede8",
    "metadata": {},
    "outputs": [
@@ -729,7 +725,7 @@
    ],
    "source": [
     "%%time\n",
-    "da = xds_wind['windspeed_10m'].groupby(\"time.date\").mean(\"time\")\n",
+    "da = xds_wind['windspeed_10m'].groupby(\"time.date\").mean(dim=\"time\")\n",
     "ds_out['windspeed_10m'] = da.compute() * 3.6  # m/s to km/hr"
    ]
   },

--- a/rex/external/rexarray.py
+++ b/rex/external/rexarray.py
@@ -867,7 +867,6 @@ def open_mfdataset_hsds(paths, **kwargs):
                "read performance.")
         warnings.warn(msg, UserWarning)
 
-
     if isinstance(paths, str):
         paths = _hsds_glob_to_list(paths)
     elif isinstance(paths, (list, tuple)):

--- a/rex/external/rexarray.py
+++ b/rex/external/rexarray.py
@@ -838,8 +838,14 @@ def open_mfdataset_hsds(paths, **kwargs):
         for more details on HSDS files.
     **kwargs
         Keyword-value argument pairs to pass to :func:`open_mfdataset`.
-        We strongly recommend specifying ``parallel=True`` and
-        ``chunks="auto"`` to help with data loading times.
+        We strongly recommend specifying the following parameters to
+        help with data loading times:
+
+            - parallel=True
+            - chunks="auto"
+            - compat="override"
+            - coords="minimal"
+
 
     Returns
     -------
@@ -851,6 +857,16 @@ def open_mfdataset_hsds(paths, **kwargs):
     """
     kwargs["engine"] = "rex"
     kwargs["hsds"] = True
+
+    if kwargs.get("compat") != "override":
+        msg = ("Did not detect 'compat='override' parameter in arguments "
+               "passed to `rex.open_mfdataset_hsds`. You may see drastically "
+               "increased loading times since all of the coordinates are "
+               "loaded and validated by xarray. We strongly recommend passing "
+               "'compat='override' (and coords='minimal') for increased "
+               "read performance.")
+        warnings.warn(msg, UserWarning)
+
 
     if isinstance(paths, str):
         paths = _hsds_glob_to_list(paths)

--- a/tests/h5pyd_tests.py
+++ b/tests/h5pyd_tests.py
@@ -87,7 +87,9 @@ def test_sup3rcc():
 def test_mf_hsds_xr(fps):
     """Test opening multiple files via HSDS with xarray"""
 
-    with open_mfdataset_hsds(fps, parallel=True, chunks="auto") as ds:
+    kwargs = {"parallel": True, "chunks": "auto", "compat": "override",
+              "coords": "minimal"}
+    with open_mfdataset_hsds(fps, **kwargs) as ds:
         assert ds.sizes == {'time': 17544, 'gid': 2488136}
         assert str(ds.time_index.isel(time=0).values).startswith("2008")
         assert str(ds.time_index.isel(time=-1).values).startswith("2009")

--- a/tests/test_rexarray.py
+++ b/tests/test_rexarray.py
@@ -28,10 +28,8 @@ WTK_2010_100M = os.path.join(TESTDATADIR, 'wtk', 'wtk_2010_100m.h5')
 WTK_2010_200M = os.path.join(TESTDATADIR, 'wtk', 'wtk_2010_200m.h5')
 
 
-def check_ti(fp, ds, group=None):
+def check_ti(truth_ti, ds):
     """Check that the time index of the dataset matches expectations"""
-    with Resource(fp, group=group) as res:
-        truth_ti = res.time_index
 
     for t_var in ["time_index", "time"]:
         assert t_var in ds.coords
@@ -87,9 +85,10 @@ def test_open_with_xr(fp):
     """Test basic opening and read operations on various files"""
     with Resource(fp) as res:
         truth_meta = res.meta
+        truth_ti = res.time_index
 
     with xr.open_dataset(fp, engine="rex") as ds:
-        check_ti(fp, ds)
+        check_ti(truth_ti, ds)
         check_meta(truth_meta, ds)
         check_shape(fp, ds)
         check_data(fp, ds)
@@ -154,9 +153,10 @@ def test_open_group():
     """Test opening a group within the file"""
     with Resource(WTK_2012_GRP_FP, group="group") as res:
         truth_meta = res.meta
+        truth_ti = res.time_index
 
     with xr.open_dataset(WTK_2012_GRP_FP, group="group", engine="rex") as ds:
-        check_ti(WTK_2012_GRP_FP, ds, group="group")
+        check_ti(truth_ti, ds)
         check_meta(truth_meta, ds)
         check_shape(WTK_2012_GRP_FP, ds, group="group")
         check_data(WTK_2012_GRP_FP, ds, group="group")
@@ -220,6 +220,9 @@ def test_detect_var_dims():
                             np.ones((8760, 1)), np.float32,
                             attrs={"units": "MW"})
 
+        with Resource(test_file) as res:
+            truth_ti = res.time_index
+
         with xr.open_dataset(test_file, engine="rex") as ds:
             assert set(ds.indexes) == {"time", "gid"}
 
@@ -237,7 +240,7 @@ def test_detect_var_dims():
             assert np.allclose(ds["latitude"], [41.29])
             assert np.allclose(ds["longitude"], [-71.86])
 
-            check_ti(test_file, ds)
+            check_ti(truth_ti, ds)
             check_shape(test_file, ds)
             check_data(test_file, ds)
 
@@ -277,9 +280,10 @@ def test_open_data_tree_no_groups(fp):
     """Test basic opening and read operations for a data tree"""
     with Resource(fp) as res:
         truth_meta = res.meta
+        truth_ti = res.time_index
 
     with xr.open_datatree(fp, engine="rex") as ds:
-        check_ti(fp, ds)
+        check_ti(truth_ti, ds)
         check_meta(truth_meta, ds)
         check_shape(fp, ds)
         check_data(fp, ds)
@@ -293,9 +297,10 @@ def test_open_data_tree_with_group():
     """Test opening a data tree for a file with a group"""
     with Resource(WTK_2012_GRP_FP, group="group") as res:
         truth_meta = res.meta
+        truth_ti = res.time_index
 
     with xr.open_datatree(WTK_2012_GRP_FP, engine="rex") as ds:
-        check_ti(WTK_2012_GRP_FP, ds["group"], group="group")
+        check_ti(truth_ti, ds["group"])
         check_meta(truth_meta, ds["group"])
         check_shape(WTK_2012_GRP_FP, ds["group"], group="group")
         check_data(WTK_2012_GRP_FP, ds["group"], group="group")

--- a/tests/test_rexarray.py
+++ b/tests/test_rexarray.py
@@ -45,10 +45,8 @@ def check_ti(fp, ds, group=None):
                            truth_ti[0:2].astype('int64'))
 
 
-def check_meta(fp, ds, group=None):
+def check_meta(truth_meta, ds):
     """Check that the meta of the dataset matches expectations"""
-    with Resource(fp, group=group) as res:
-        truth_meta = res.meta
 
     for col in truth_meta.columns:
         truth_vals = truth_meta[col].to_numpy()
@@ -87,9 +85,12 @@ def check_data(fp, ds, group=None):
                                 NSRDB_2013, WAVE_2010])
 def test_open_with_xr(fp):
     """Test basic opening and read operations on various files"""
+    with Resource(fp) as res:
+        truth_meta = res.meta
+
     with xr.open_dataset(fp, engine="rex") as ds:
         check_ti(fp, ds)
-        check_meta(fp, ds)
+        check_meta(truth_meta, ds)
         check_shape(fp, ds)
         check_data(fp, ds)
 
@@ -151,9 +152,12 @@ def test_ds_attrs():
 
 def test_open_group():
     """Test opening a group within the file"""
+    with Resource(WTK_2012_GRP_FP, group="group") as res:
+        truth_meta = res.meta
+
     with xr.open_dataset(WTK_2012_GRP_FP, group="group", engine="rex") as ds:
         check_ti(WTK_2012_GRP_FP, ds, group="group")
-        check_meta(WTK_2012_GRP_FP, ds, group="group")
+        check_meta(truth_meta, ds)
         check_shape(WTK_2012_GRP_FP, ds, group="group")
         check_data(WTK_2012_GRP_FP, ds, group="group")
 
@@ -271,9 +275,12 @@ def test_coords_dset():
                                 NSRDB_2013, WAVE_2010])
 def test_open_data_tree_no_groups(fp):
     """Test basic opening and read operations for a data tree"""
+    with Resource(fp) as res:
+        truth_meta = res.meta
+
     with xr.open_datatree(fp, engine="rex") as ds:
         check_ti(fp, ds)
-        check_meta(fp, ds)
+        check_meta(truth_meta, ds)
         check_shape(fp, ds)
         check_data(fp, ds)
 
@@ -284,9 +291,12 @@ def test_open_data_tree_no_groups(fp):
                     reason="DataTrees require Python 3.10+ to run")
 def test_open_data_tree_with_group():
     """Test opening a data tree for a file with a group"""
+    with Resource(WTK_2012_GRP_FP, group="group") as res:
+        truth_meta = res.meta
+
     with xr.open_datatree(WTK_2012_GRP_FP, engine="rex") as ds:
         check_ti(WTK_2012_GRP_FP, ds["group"], group="group")
-        check_meta(WTK_2012_GRP_FP, ds["group"], group="group")
+        check_meta(truth_meta, ds["group"])
         check_shape(WTK_2012_GRP_FP, ds["group"], group="group")
         check_data(WTK_2012_GRP_FP, ds["group"], group="group")
 

--- a/tests/test_rexarray.py
+++ b/tests/test_rexarray.py
@@ -66,12 +66,10 @@ def check_shape(truth_shape, ds):
     assert ds.sizes == {'time': truth_shape[0], 'gid': truth_shape[1]}
 
 
-def check_data(fp, ds, group=None):
+def check_data(truth_datasets, ds):
     """Check that the values of the dataset match expectations"""
-    with Resource(fp, group=group) as res:
-        datasets = {d_name: res[d_name][:] for d_name in res.resource_datasets}
 
-    for name, values in datasets.items():
+    for name, values in truth_datasets.items():
         assert np.allclose(ds[name], values)
 
 
@@ -84,12 +82,13 @@ def test_open_with_xr(fp):
         truth_meta = res.meta
         truth_ti = res.time_index
         truth_shape = res.shape
+        truth_datasets = {name: res[name][:] for name in res.resource_datasets}
 
     with xr.open_dataset(fp, engine="rex") as ds:
         check_ti(truth_ti, ds)
         check_meta(truth_meta, ds)
         check_shape(truth_shape, ds)
-        check_data(fp, ds)
+        check_data(truth_datasets, ds)
 
         assert set(ds.indexes) == {"time", "gid"}
 
@@ -153,12 +152,13 @@ def test_open_group():
         truth_meta = res.meta
         truth_ti = res.time_index
         truth_shape = res.shape
+        truth_datasets = {name: res[name][:] for name in res.resource_datasets}
 
     with xr.open_dataset(WTK_2012_GRP_FP, group="group", engine="rex") as ds:
         check_ti(truth_ti, ds)
         check_meta(truth_meta, ds)
         check_shape(truth_shape, ds)
-        check_data(WTK_2012_GRP_FP, ds, group="group")
+        check_data(truth_datasets, ds)
 
 
 @pytest.mark.parametrize(
@@ -222,6 +222,8 @@ def test_detect_var_dims():
         with Resource(test_file) as res:
             truth_ti = res.time_index
             truth_shape = res.shape
+            truth_datasets = {name: res[name][:]
+                              for name in res.resource_datasets}
 
         with xr.open_dataset(test_file, engine="rex") as ds:
             assert set(ds.indexes) == {"time", "gid"}
@@ -242,7 +244,7 @@ def test_detect_var_dims():
 
             check_ti(truth_ti, ds)
             check_shape(truth_shape, ds)
-            check_data(test_file, ds)
+            check_data(truth_datasets, ds)
 
 
 def test_coords_dset():
@@ -282,12 +284,13 @@ def test_open_data_tree_no_groups(fp):
         truth_meta = res.meta
         truth_ti = res.time_index
         truth_shape = res.shape
+        truth_datasets = {name: res[name][:] for name in res.resource_datasets}
 
     with xr.open_datatree(fp, engine="rex") as ds:
         check_ti(truth_ti, ds)
         check_meta(truth_meta, ds)
         check_shape(truth_shape, ds)
-        check_data(fp, ds)
+        check_data(truth_datasets, ds)
 
         assert set(ds.indexes) == {"time", "gid"}
 
@@ -300,12 +303,13 @@ def test_open_data_tree_with_group():
         truth_meta = res.meta
         truth_ti = res.time_index
         truth_shape = res.shape
+        truth_datasets = {name: res[name][:] for name in res.resource_datasets}
 
     with xr.open_datatree(WTK_2012_GRP_FP, engine="rex") as ds:
         check_ti(truth_ti, ds["group"])
         check_meta(truth_meta, ds["group"])
         check_shape(truth_shape, ds["group"])
-        check_data(WTK_2012_GRP_FP, ds["group"], group="group")
+        check_data(truth_datasets, ds["group"])
 
 
 def execute_pytest(capture='all', flags='-rapP'):

--- a/tests/test_rexarray.py
+++ b/tests/test_rexarray.py
@@ -61,11 +61,8 @@ def check_meta(truth_meta, ds):
                            truth_vals[0:2])
 
 
-def check_shape(fp, ds, group=None):
+def check_shape(truth_shape, ds):
     """Check that the shape of the dataset matches expectations"""
-    with Resource(fp, group=group) as res:
-        truth_shape = res.shape
-
     assert ds.sizes == {'time': truth_shape[0], 'gid': truth_shape[1]}
 
 
@@ -86,11 +83,12 @@ def test_open_with_xr(fp):
     with Resource(fp) as res:
         truth_meta = res.meta
         truth_ti = res.time_index
+        truth_shape = res.shape
 
     with xr.open_dataset(fp, engine="rex") as ds:
         check_ti(truth_ti, ds)
         check_meta(truth_meta, ds)
-        check_shape(fp, ds)
+        check_shape(truth_shape, ds)
         check_data(fp, ds)
 
         assert set(ds.indexes) == {"time", "gid"}
@@ -154,11 +152,12 @@ def test_open_group():
     with Resource(WTK_2012_GRP_FP, group="group") as res:
         truth_meta = res.meta
         truth_ti = res.time_index
+        truth_shape = res.shape
 
     with xr.open_dataset(WTK_2012_GRP_FP, group="group", engine="rex") as ds:
         check_ti(truth_ti, ds)
         check_meta(truth_meta, ds)
-        check_shape(WTK_2012_GRP_FP, ds, group="group")
+        check_shape(truth_shape, ds)
         check_data(WTK_2012_GRP_FP, ds, group="group")
 
 
@@ -222,6 +221,7 @@ def test_detect_var_dims():
 
         with Resource(test_file) as res:
             truth_ti = res.time_index
+            truth_shape = res.shape
 
         with xr.open_dataset(test_file, engine="rex") as ds:
             assert set(ds.indexes) == {"time", "gid"}
@@ -241,7 +241,7 @@ def test_detect_var_dims():
             assert np.allclose(ds["longitude"], [-71.86])
 
             check_ti(truth_ti, ds)
-            check_shape(test_file, ds)
+            check_shape(truth_shape, ds)
             check_data(test_file, ds)
 
 
@@ -281,11 +281,12 @@ def test_open_data_tree_no_groups(fp):
     with Resource(fp) as res:
         truth_meta = res.meta
         truth_ti = res.time_index
+        truth_shape = res.shape
 
     with xr.open_datatree(fp, engine="rex") as ds:
         check_ti(truth_ti, ds)
         check_meta(truth_meta, ds)
-        check_shape(fp, ds)
+        check_shape(truth_shape, ds)
         check_data(fp, ds)
 
         assert set(ds.indexes) == {"time", "gid"}
@@ -298,11 +299,12 @@ def test_open_data_tree_with_group():
     with Resource(WTK_2012_GRP_FP, group="group") as res:
         truth_meta = res.meta
         truth_ti = res.time_index
+        truth_shape = res.shape
 
     with xr.open_datatree(WTK_2012_GRP_FP, engine="rex") as ds:
         check_ti(truth_ti, ds["group"])
         check_meta(truth_meta, ds["group"])
-        check_shape(WTK_2012_GRP_FP, ds["group"], group="group")
+        check_shape(truth_shape, ds["group"])
         check_data(WTK_2012_GRP_FP, ds["group"], group="group")
 
 

--- a/tests/test_rexarray.py
+++ b/tests/test_rexarray.py
@@ -169,22 +169,32 @@ def test_open_group():
 def test_open_mf_year(glob_fp):
     """Test opening a multi-file dataset across years"""
     with MultiYearResource(glob_fp) as res:
+        truth_meta = res.meta
+        truth_ti = res.time_index
         truth_shape = res.shape
+        truth_datasets = {name: res[name][:] for name in res.resource_datasets}
 
     with xr.open_mfdataset(glob_fp, engine="rex") as ds:
-        assert ds.sizes == {'time': truth_shape[0], 'gid': truth_shape[1]}
+        check_meta(truth_meta, ds)
+        check_ti(truth_ti, ds)
+        check_shape(truth_shape, ds)
+        check_data(truth_datasets, ds)
 
 
 def test_open_mf_ds():
     """Test opening multi-file dataset across variables"""
     glob_fp = os.path.join(TESTDATADIR, 'wtk', 'wtk_2010_*m.h5')
     with MultiFileResource(glob_fp) as res:
+        truth_meta = res.meta
+        truth_ti = res.time_index
         truth_shape = res.shape
-        datasets = res.resource_datasets
+        truth_datasets = {name: res[name][:] for name in res.resource_datasets}
 
     with xr.open_mfdataset(glob_fp, engine="rex") as ds:
-        assert ds.sizes == {'time': truth_shape[0], 'gid': truth_shape[1]}
-        assert all(ds_name in ds for ds_name in datasets)
+        check_meta(truth_meta, ds)
+        check_ti(truth_ti, ds)
+        check_shape(truth_shape, ds)
+        check_data(truth_datasets, ds)
 
 
 def test_open_drop_var():

--- a/tests/test_rexarray.py
+++ b/tests/test_rexarray.py
@@ -197,6 +197,44 @@ def test_open_mf_ds():
         check_data(truth_datasets, ds)
 
 
+@pytest.mark.parametrize(
+    'glob_fp',
+    [os.path.join(TESTDATADIR, 'nsrdb', 'ri_100_nsrdb_201*.h5'),
+     os.path.join(TESTDATADIR, 'sza', 'nsrdb_sza_201*.h5'),
+     os.path.join(TESTDATADIR, 'wtk', 'ri_100_wtk_201*.h5')])
+def test_open_mf_year_override_compat(glob_fp):
+    """Test opening a multi-file dataset across years with no compat"""
+    with MultiYearResource(glob_fp) as res:
+        truth_meta = res.meta
+        truth_ti = res.time_index
+        truth_shape = res.shape
+        truth_datasets = {name: res[name][:] for name in res.resource_datasets}
+
+    kwargs = {'engine': 'rex', 'compat': 'override', 'coords': 'minimal'}
+    with xr.open_mfdataset(glob_fp, **kwargs) as ds:
+        check_meta(truth_meta, ds)
+        check_ti(truth_ti, ds)
+        check_shape(truth_shape, ds)
+        check_data(truth_datasets, ds)
+
+
+def test_open_mf_ds_override_compat():
+    """Test opening multi-file dataset across variables"""
+    glob_fp = os.path.join(TESTDATADIR, 'wtk', 'wtk_2010_*m.h5')
+    with MultiFileResource(glob_fp) as res:
+        truth_meta = res.meta
+        truth_ti = res.time_index
+        truth_shape = res.shape
+        truth_datasets = {name: res[name][:] for name in res.resource_datasets}
+
+    kwargs = {'engine': 'rex', 'compat': 'override', 'coords': 'minimal'}
+    with xr.open_mfdataset(glob_fp, **kwargs) as ds:
+        check_meta(truth_meta, ds)
+        check_ti(truth_ti, ds)
+        check_shape(truth_shape, ds)
+        check_data(truth_datasets, ds)
+
+
 def test_open_drop_var():
     """Test dropping of variables when opening a file"""
     with xr.open_dataset(WTK_2012_FP, engine="rex") as ds:


### PR DESCRIPTION
By default `xarray` will attempt to validate coordinates during concatenation. Since rex-style data coordinates are known to match, it;s better to skip this validation step in order to get a huge performance gain when using `xarray .open_mfdataset`. This PR adds some notes about this and a warning to the `open_mfdataset_hsfs` function