### PR TITLE
Add fallback if accessing HSDS fails

### DIFF
--- a/rex/utilities/utilities.py
+++ b/rex/utilities/utilities.py
@@ -344,8 +344,11 @@ def check_res_file(res_file):
         raise FileInputError(msg)
 
     else:
-        multi_h5_res, hsds = check_hsds_file(res_file)
-        bad = not hsds
+        try:
+            multi_h5_res, hsds = check_hsds_file(res_file)
+            bad = not hsds
+        except OSError:  # cannot connect to HSDS
+            bad = True
 
     if bad:
         msg = ("{} is not a valid file path, and HSDS "

--- a/rex/utilities/utilities.py
+++ b/rex/utilities/utilities.py
@@ -347,7 +347,7 @@ def check_res_file(res_file):
         try:
             multi_h5_res, hsds = check_hsds_file(res_file)
             bad = not hsds
-        except OSError:  # cannot connect to HSDS
+        except (OSError, ValueError):  # cannot connect to HSDS
             bad = True
 
     if bad:

--- a/rex/version.py
+++ b/rex/version.py
@@ -1,3 +1,3 @@
 """rex Version number"""
 
-__version__ = "0.3.4"
+__version__ = "0.3.5"

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -9,7 +9,7 @@ from tempfile import TemporaryDirectory
 import pandas as pd
 import pytest
 
-from rex.utilities import parse_table
+from rex.utilities import parse_table, check_res_file
 from rex import TESTDATADIR
 
 NSRDB_DIR = os.path.join(TESTDATADIR, 'nsrdb')
@@ -48,6 +48,25 @@ def test_parse_table():
 
     with pytest.raises(ValueError):
         parse_table([0, 1, 2])
+
+
+def test_check_res_file_dne():
+    """Test check_res_file() when file does not exist"""
+    with TemporaryDirectory() as td:
+        test_file = os.path.join(td, "gen.h5")
+
+        with pytest.raises(FileNotFoundError) as error:
+            check_res_file(test_file)
+
+        expected_msg = ("gen.h5 is not a valid file path, and HSDS cannot "
+                        "be checked for a file at this path!")
+        assert expected_msg in str(error)
+
+        open(test_file, "w").close()
+        multi_file, hsds = check_res_file(test_file)
+
+        assert not multi_file
+        assert not hsds
 
 
 def execute_pytest(capture='all', flags='-rapP'):

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -62,7 +62,7 @@ def test_check_res_file_dne():
                         "be checked for a file at this path!")
         assert expected_msg in str(error)
 
-        open(test_file, "w").close()
+        open(test_file, "w").close()  # pylint: disable=consider-using-with
         multi_file, hsds = check_res_file(test_file)
 
         assert not multi_file


### PR DESCRIPTION
in `check_res_file` function, if HSDS cannot be connected to (either service is unreachable or folder is incorrect), report that back to caller instead of erroring out