### PR TITLE
Guard `getpass` call

### DIFF
--- a/rex/utilities/hpc.py
+++ b/rex/utilities/hpc.py
@@ -21,9 +21,6 @@ logger = logging.getLogger(__name__)
 class HpcJobManager(SubprocessManager, ABC):
     """Abstract HPC job manager framework"""
 
-    # get username as class attribute.
-    USER = getpass.getuser()
-
     # HPC queue column headers
     QCOL_NAME = None  # Job name column
     QCOL_ID = None  # Job integer ID column
@@ -46,10 +43,7 @@ class HpcJobManager(SubprocessManager, ABC):
             from parse_queue_str(). None will get the queue from PBS or SLURM.
         """
 
-        self._user = user
-        if self._user is None:
-            self._user = self.USER
-
+        self._user = user or getpass.getuser()
         if queue_dict is not None and not isinstance(queue_dict, dict):
             emsg = ('HPC queue_dict arg must be None or Dict but received: '
                     '{}, {}'.format(queue_dict, type(queue_dict)))
@@ -268,7 +262,7 @@ class PBS(HpcJobManager):
         """
 
         if user is None:
-            user = cls.USER
+            user = getpass.getuser()
 
         if skip_rows is None:
             skip_rows = cls.QSKIP
@@ -433,7 +427,7 @@ class SLURM(HpcJobManager):
             job_name_str = ' -n {}'.format(job_name)
 
         if user is None:
-            user = cls.USER
+            user = getpass.getuser()
 
         if qformat is None:
             qformat = cls.SQ_FORMAT

--- a/rex/version.py
+++ b/rex/version.py
@@ -1,3 +1,3 @@
 """rex Version number"""
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"


### PR DESCRIPTION
Per the [documentation](https://docs.python.org/3.13/library/getpass.html#getpass.getuser) of `getpass.getuser`, the call will throw an `OSError` on systems without access to the `pwd` module. This means importing `rex` can fail completely since we have a `getpass.getuser` call on import. In this PR, we delay the call to `getpass.getuser` until an HPC class instance is being created, allowing `rex` itself to be imported and used on systems missing `pwd`. 