### PR TITLE
Fix MP for make SAM files function

### DIFF
--- a/rex/resource_extraction/resource_extraction.py
+++ b/rex/resource_extraction/resource_extraction.py
@@ -921,8 +921,10 @@ class ResourceX(BaseDatasetIterable):
             If multiple lat, lon pairs are given a list of DatFrames is
             returned
         """
+        needs_gid_suffix = True
         if isinstance(gid, (int, np.integer)):
             gid = [gid]
+            needs_gid_suffix = False
 
         SAM_df = []
         for res_id in gid:
@@ -933,7 +935,7 @@ class ResourceX(BaseDatasetIterable):
             if out_path is not None:
                 assert out_path.endswith('.csv'), 'out_path must be .csv!'
                 i_out_path = out_path
-                if len(gid) > 1:
+                if needs_gid_suffix:
                     tag = '_{}.csv'.format(res_id)
                     i_out_path = i_out_path.replace('.csv', tag)
 

--- a/rex/version.py
+++ b/rex/version.py
@@ -1,3 +1,3 @@
 """rex Version number"""
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"

--- a/tests/test_resource_extraction.py
+++ b/tests/test_resource_extraction.py
@@ -117,8 +117,13 @@ def test_sam_csv_with_extra_commas(NSRDBX_cls):
 
     with tempfile.TemporaryDirectory() as td:
         out_path = os.path.join(td, 'test.csv')
+        assert not os.path.exists(out_path)
+
         NSRDBX_cls.get_SAM_gid(0, out_path=out_path,
                                extra_meta_data={"urban": "Washington, D.C."})
+        assert os.path.exists(out_path)
+        assert not os.path.exists(os.path.join(td, 'test_0.csv'))
+
         with open(out_path) as fh:
             col_names = fh.readline()
             values = fh.readline()
@@ -852,7 +857,12 @@ def test_cli_SAM(runner, WindX_cls):
     path = os.path.join(TESTDATADIR, 'wtk/ri_100_wtk_2012.h5')
     with tempfile.TemporaryDirectory() as td:
         truth_path = os.path.join(td, 'truth.csv')
+        assert not os.path.exists(truth_path)
+
         WindX_cls.get_SAM_gid(gid, 100, out_path=truth_path)
+        assert os.path.exists(truth_path)
+        assert not os.path.exists(os.path.join(td, f'test_{gid}.csv'))
+
         truth = pd.read_csv(truth_path, skiprows=1)
 
         result = runner.invoke(main, ['-h5', path,

--- a/tests/test_resource_extraction.py
+++ b/tests/test_resource_extraction.py
@@ -872,7 +872,8 @@ def test_cli_SAM(runner, WindX_cls):
     LOGGERS.clear()
 
 
-def test_windx_make_SAM_files(WindX_cls):
+@pytest.mark.parametrize('max_workers', [1, 2])
+def test_windx_make_SAM_files(WindX_cls, max_workers):
     """
     Test WindX make_SAM_files method
     """
@@ -885,7 +886,8 @@ def test_windx_make_SAM_files(WindX_cls):
         WindX_cls.get_SAM_gid(gids, 100, out_path=truth_path)
 
         test_path = os.path.join(td, 'test.csv')
-        WindX.make_SAM_files(path, gids, hub_height=100, out_path=test_path)
+        WindX.make_SAM_files(path, gids, hub_height=100, out_path=test_path,
+                             max_workers=max_workers)
         for gid in gids:
             test_path = os.path.join(td, f'test_{gid}.csv')
             truth_path = os.path.join(td, f'truth_{gid}.csv')
@@ -923,7 +925,8 @@ def test_windx_run_SAM_files():
     LOGGERS.clear()
 
 
-def test_nsrdbx_make_SAM_files(NSRDBX_cls):
+@pytest.mark.parametrize('max_workers', [1, 2])
+def test_nsrdbx_make_SAM_files(NSRDBX_cls, max_workers):
     """
     Test nsrdbx make_SAM_files method
     """
@@ -936,7 +939,8 @@ def test_nsrdbx_make_SAM_files(NSRDBX_cls):
         NSRDBX_cls.get_SAM_gid(gids, out_path=truth_path)
 
         test_path = os.path.join(td, 'test.csv')
-        NSRDBX.make_SAM_files(path, gids, out_path=test_path)
+        NSRDBX.make_SAM_files(path, gids, out_path=test_path,
+                              max_workers=max_workers)
         for gid in gids:
             test_path = os.path.join(td, f'test_{gid}.csv')
             truth_path = os.path.join(td, f'truth_{gid}.csv')

--- a/tests/test_resource_extraction.py
+++ b/tests/test_resource_extraction.py
@@ -881,9 +881,8 @@ def test_windx_make_SAM_files(WindX_cls):
 
     path = os.path.join(TESTDATADIR, 'wtk/ri_100_wtk_2012.h5')
     with tempfile.TemporaryDirectory() as td:
-        for gid in gids:
-            truth_path = os.path.join(td, f'truth_{gid}.csv')
-            WindX_cls.get_SAM_gid(gid, 100, out_path=truth_path)
+        truth_path = os.path.join(td, 'truth.csv')
+        WindX_cls.get_SAM_gid(gids, 100, out_path=truth_path)
 
         test_path = os.path.join(td, 'test.csv')
         WindX.make_SAM_files(path, gids, hub_height=100, out_path=test_path)
@@ -921,7 +920,6 @@ def test_windx_run_SAM_files():
         obj.execute()
         assert obj.Outputs.annual_energy < energy_no_icing
 
-
     LOGGERS.clear()
 
 
@@ -934,9 +932,8 @@ def test_nsrdbx_make_SAM_files(NSRDBX_cls):
 
     path = os.path.join(TESTDATADIR, 'nsrdb/ri_100_nsrdb_2012.h5')
     with tempfile.TemporaryDirectory() as td:
-        for gid in gids:
-            truth_path = os.path.join(td, f'truth_{gid}.csv')
-            NSRDBX_cls.get_SAM_gid(gid, out_path=truth_path)
+        truth_path = os.path.join(td, 'truth.csv')
+        NSRDBX_cls.get_SAM_gid(gids, out_path=truth_path)
 
         test_path = os.path.join(td, 'test.csv')
         NSRDBX.make_SAM_files(path, gids, out_path=test_path)


### PR DESCRIPTION
Previously, `make_SAM_files` would overwrite the same file when num gids < num chunks. In this PR, we fix this by always adding a gid suffix if the user passes an iterable of GI's, even if that iterable only contains one value. The old behavior of not adding a suffix is preserved and explicitly tested for when the user intentionally passes a single GID (as an int) to the `get_SAM_gid` function. 