### PR TITLE
Fix attrs in Outputs getting overwritten

### DIFF
--- a/rex/outputs.py
+++ b/rex/outputs.py
@@ -211,7 +211,7 @@ class Outputs(BaseResource):
         """Set the version attribute to the h5 file."""
         new_attrs = {'version': __version__,
                      'full_version_record': json.dumps(
-                        self.full_version_record),
+                         self.full_version_record),
                      'package': 'rex'}
         for name, value in new_attrs.items():
             if name not in self.h5.attrs:
@@ -571,7 +571,7 @@ class Outputs(BaseResource):
             msg = ('Shape dimensions ({}) are not the same length as chunks '
                    '({}). Please provide a single chunk value for each '
                    'dimension!'
-                    .format(shape, chunks))
+                   .format(shape, chunks))
             logger.error(msg)
             raise HandlerRuntimeError(msg)
 
@@ -751,6 +751,7 @@ class Outputs(BaseResource):
 
         keys = (dset, ) + dset_slice
 
+        # pylint: disable=unnecessary-dunder-call
         arr = self.__getitem__(keys)
         if not np.array_equal(arr, dset_array):
             self._set_ds_array(dset, dset_array, dset_slice)

--- a/rex/outputs.py
+++ b/rex/outputs.py
@@ -209,10 +209,13 @@ class Outputs(BaseResource):
 
     def set_version_attr(self):
         """Set the version attribute to the h5 file."""
-        self.h5.attrs['version'] = __version__
-        self.h5.attrs['full_version_record'] = json.dumps(
-            self.full_version_record)
-        self.h5.attrs['package'] = 'rex'
+        new_attrs = {'version': __version__,
+                     'full_version_record': json.dumps(
+                        self.full_version_record),
+                     'package': 'rex'}
+        for name, value in new_attrs.items():
+            if name not in self.h5.attrs:
+                self.h5.attrs[name] = value
 
     @property
     def version(self):

--- a/rex/outputs.py
+++ b/rex/outputs.py
@@ -196,14 +196,14 @@ class Outputs(BaseResource):
         dict
             Dictionary of package versions for dependencies
         """
-        versions = {'rex': __version__,
-                    'pandas': pd.__version__,
-                    'numpy': np.__version__,
-                    'python': sys.version,
-                    'click': click.__version__,
+        versions = {'python': sys.version,
+                    'rex': __version__,
                     'h5py': h5py.__version__,
                     'h5pyd': h5pyd.__version__,
-                    'scipy': scipy.__version__
+                    'pandas': pd.__version__,
+                    'numpy': np.__version__,
+                    'scipy': scipy.__version__,
+                    'click': click.__version__,
                     }
         return versions
 

--- a/rex/version.py
+++ b/rex/version.py
@@ -1,3 +1,3 @@
 """rex Version number"""
 
-__version__ = "0.4.2"
+__version__ = "0.4.3"

--- a/tests/test_outputs.py
+++ b/tests/test_outputs.py
@@ -253,6 +253,23 @@ def test_1D_dataset_shape():
             assert res['dset3'].shape == (8760,)
 
 
+def test_attrs_multiple_opens():
+    """Test that attrs are not overwritten on multiple opens"""
+
+    attrs_to_test = ["package", "version", "full_version_record"]
+    with tempfile.TemporaryDirectory() as td:
+        fp = os.path.join(td, 'outputs.h5')
+        with Outputs(fp, 'a') as f:
+            for attr in attrs_to_test:
+                assert f.h5.attrs[attr] != "test"
+                f.h5.attrs[attr] = "test"
+                assert f.h5.attrs[attr] == "test"
+
+        with Outputs(fp, 'a') as f:
+            for attr in attrs_to_test:
+                assert f.h5.attrs["package"] == "test"
+
+
 def execute_pytest(capture='all', flags='-rapP'):
     """Execute module as pytest with detailed summary report.
 


### PR DESCRIPTION
Before writing tha attrs, make sure they don't already exist so that we don't clobber some user-defined attrs.